### PR TITLE
Fix Deployment Transfers

### DIFF
--- a/playground.php
+++ b/playground.php
@@ -45,14 +45,14 @@ $sourceNHost = new NHost(
     $_ENV['NHOST_TEST_PASSWORD'] ?? '',
 );
 
-$sourceSupabase = new Supabase(
-    $_ENV['SUPABASE_TEST_ENDPOINT'] ?? '',
-    $_ENV['SUPABASE_TEST_KEY'] ?? '',
-    $_ENV['SUPABASE_TEST_HOST'] ?? '',
-    $_ENV['SUPABASE_TEST_DATABASE'] ?? '',
-    $_ENV['SUPABASE_TEST_USERNAME'] ?? '',
-    $_ENV['SUPABASE_TEST_PASSWORD'] ?? '',
-);
+// $sourceSupabase = new Supabase(
+//     $_ENV['SUPABASE_TEST_ENDPOINT'] ?? '',
+//     $_ENV['SUPABASE_TEST_KEY'] ?? '',
+//     $_ENV['SUPABASE_TEST_HOST'] ?? '',
+//     $_ENV['SUPABASE_TEST_DATABASE'] ?? '',
+//     $_ENV['SUPABASE_TEST_USERNAME'] ?? '',
+//     $_ENV['SUPABASE_TEST_PASSWORD'] ?? '',
+// );
 
 /**
  * Initialise All Destination Adapters
@@ -69,16 +69,16 @@ $destinationLocal = new Local(__DIR__.'/localBackup/');
  * Initialise Transfer Class
  */
 $transfer = new Transfer(
-    $sourceFirebase,
+    $sourceAppwrite,
     $destinationLocal
 );
 
-$sourceFirebase->report();
+$sourceAppwrite->report();
 
 // /**
 //  * Run Transfer
 //  */
-$transfer->run($sourceFirebase->getSupportedResources(),
+$transfer->run(Appwrite::getSupportedResources(),
     function (array $resources) {
     }
 );

--- a/src/Migration/Cache.php
+++ b/src/Migration/Cache.php
@@ -2,7 +2,6 @@
 
 namespace Utopia\Migration;
 
-use Utopia\Migration\Resources\Functions\Func;
 use Utopia\Migration\Resources\Storage\File;
 
 /**

--- a/src/Migration/Cache.php
+++ b/src/Migration/Cache.php
@@ -37,8 +37,8 @@ class Cache
             $resource->setInternalId(uniqid());
         }
 
-        if ($resource->getName() == Resource::TYPE_FILE || $resource->getName() == Resource::TYPE_FUNCTION) {
-            /** @var File|Func $resource */
+        if ($resource->getName() == Resource::TYPE_FILE || $resource->getName() == Resource::TYPE_DEPLOYMENT) {
+            /** @var File|Deployment $resource */
             $resource->setData(''); // Prevent Memory Leak
         }
 

--- a/src/Migration/Destinations/Local.php
+++ b/src/Migration/Destinations/Local.php
@@ -104,7 +104,7 @@ class Local extends Destination
                 case Resource::TYPE_DEPLOYMENT:
                     /** @var Deployment $resource */
                     if ($resource->getStart() === 0) {
-                        $this->data[$resource->getGroup()][$resource->getName()][$resource->getInternalId()] = $resource->asArray();
+                        $this->data[$resource->getGroup()][$resource->getName()][] = $resource->asArray();
                     }
 
                     file_put_contents($this->path.'deployments/'.$resource->getId().'.tar.gz', $resource->getData(), FILE_APPEND);
@@ -135,7 +135,7 @@ class Local extends Destination
                     $resource->setData('');
                     break;
                 default:
-                    $this->data[$resource->getGroup()][$resource->getName()][$resource->getInternalId()] = $resource->asArray();
+                    $this->data[$resource->getGroup()][$resource->getName()][]= $resource->asArray();
                     break;
             }
 

--- a/src/Migration/Destinations/Local.php
+++ b/src/Migration/Destinations/Local.php
@@ -135,7 +135,7 @@ class Local extends Destination
                     $resource->setData('');
                     break;
                 default:
-                    $this->data[$resource->getGroup()][$resource->getName()][]= $resource->asArray();
+                    $this->data[$resource->getGroup()][$resource->getName()][] = $resource->asArray();
                     break;
             }
 

--- a/src/Migration/Resource.php
+++ b/src/Migration/Resource.php
@@ -44,15 +44,17 @@ abstract class Resource
 
     public const TYPE_INDEX = 'index';
 
+    public const TYPE_INACTIVE_DEPLOYMENTS = 'inactive-deployments';
+
+    public const TYPE_DEPLOYMENT = 'deployment';
+
+    public const TYPE_ENVVAR = 'envvar';
+
     // Children (Resources that are created by other resources)
 
     public const TYPE_ATTRIBUTE = 'attribute';
 
-    public const TYPE_DEPLOYMENT = 'deployment';
-
     public const TYPE_HASH = 'hash';
-
-    public const TYPE_ENVVAR = 'envvar';
 
     public const ALL_RESOURCES = [
         self::TYPE_ATTRIBUTE,

--- a/src/Migration/Resources/Functions/Func.php
+++ b/src/Migration/Resources/Functions/Func.php
@@ -21,7 +21,9 @@ class Func extends Resource
 
     protected int $timeout;
 
-    public function __construct(string $name, string $id, string $runtime, array $execute = [], bool $enabled = true, array $events = [], string $schedule = '', int $timeout = 0)
+    protected string $deployment;
+
+    public function __construct(string $name, string $id, string $runtime, array $execute = [], bool $enabled = true, array $events = [], string $schedule = '', int $timeout = 0, string $deployment = '')
     {
         $this->name = $name;
         $this->id = $id;
@@ -31,6 +33,7 @@ class Func extends Resource
         $this->events = $events;
         $this->schedule = $schedule;
         $this->timeout = $timeout;
+        $this->deployment = $deployment;
     }
 
     public static function getName(): string
@@ -120,6 +123,18 @@ class Func extends Resource
         return $this;
     }
 
+    public function getDeployment(): string
+    {
+        return $this->deployment;
+    }
+
+    public function setDeployment(string $deployment): self
+    {
+        $this->deployment = $deployment;
+
+        return $this;
+    }
+
     public function asArray(): array
     {
         return [
@@ -131,6 +146,7 @@ class Func extends Resource
             'events' => $this->events,
             'schedule' => $this->schedule,
             'timeout' => $this->timeout,
+            'deployment' => $this->deployment
         ];
     }
 }

--- a/src/Migration/Resources/Functions/Func.php
+++ b/src/Migration/Resources/Functions/Func.php
@@ -146,7 +146,7 @@ class Func extends Resource
             'events' => $this->events,
             'schedule' => $this->schedule,
             'timeout' => $this->timeout,
-            'deployment' => $this->deployment
+            'deployment' => $this->deployment,
         ];
     }
 }

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -1065,7 +1065,7 @@ class Appwrite extends Source
                 );
 
                 foreach ($response['deployments'] as $deployment) {
-                    if (!$includeInactive && ($deployment['$id'] != $func->getDeployment())) {
+                    if (! $includeInactive && ($deployment['$id'] != $func->getDeployment())) {
                         continue;
                     }
 

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -987,7 +987,7 @@ class Appwrite extends Source
     protected function exportGroupFunctions(int $batchSize, array $resources)
     {
         if (in_array(Resource::TYPE_FUNCTION, $resources)) {
-            $this->exportFunctions($batchSize);
+            $this->exportFunctions($batchSize, $resources);
         }
 
         if (in_array(Resource::TYPE_DEPLOYMENT, $resources)) {
@@ -995,7 +995,7 @@ class Appwrite extends Source
         }
     }
 
-    private function exportFunctions(int $batchSize)
+    private function exportFunctions(int $batchSize, array $resources)
     {
         $functionsClient = new Functions($this->client);
 
@@ -1022,12 +1022,14 @@ class Appwrite extends Source
 
             $convertedResources[] = $convertedFunc;
 
-            foreach ($function['vars'] as $var) {
-                $convertedResources[] = new EnvVar(
-                    $convertedFunc,
-                    $var['key'],
-                    $var['value'],
-                );
+            if (in_array(Resource::TYPE_ENVVAR, $resources)) {
+                foreach ($function['vars'] as $var) {
+                    $convertedResources[] = new EnvVar(
+                        $convertedFunc,
+                        $var['key'],
+                        $var['value'],
+                    );
+                }
             }
         }
 

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -101,6 +101,7 @@ class Appwrite extends Source
             // Functions
             Resource::TYPE_FUNCTION,
             Resource::TYPE_DEPLOYMENT,
+            Resource::TYPE_INACTIVE_DEPLOYMENTS,
             Resource::TYPE_ENVVAR,
 
             // Settings


### PR DESCRIPTION
This adds a patch to:

1. Ignore Deployments data structures in the cache instead of incorrectly setting functions type's data
2. Adds the ability to ignore old deployments by remembering function's deploymentIds within the class
3. Adds EnvVar optionals