### PR TITLE
Fix a team membership migration bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
         "format": "./vendor/bin/pint"
     },
     "require": {
-        "php": ">=8.0",
-        "utopia-php/cli": "^0.15.0",
-        "appwrite/appwrite": "^10.0.0"
+        "php": "8.*",
+        "utopia-php/cli": "0.*",
+        "appwrite/appwrite": "10.0.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3",
-        "vlucas/phpdotenv": "^5.5",
-        "laravel/pint": "^1.10"
+        "phpunit/phpunit": "9.*",
+        "vlucas/phpdotenv": "5.*",
+        "laravel/pint": "1.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=8.0",
         "utopia-php/cli": "^0.15.0",
-        "appwrite/appwrite": "^8.0"
+        "appwrite/appwrite": "^10.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -575,11 +575,7 @@ class Appwrite extends Destination
                     $teamService->createMembership(
                         $resource->getTeam()->getId(),
                         $resource->getRoles(),
-                        '',
-                        $user->getEmail(),
-                        $user->getId(),
-                        $user->getPhone(),
-                        $user->getName()
+                        userId: $user->getId(),
                     );
                     break;
             }


### PR DESCRIPTION
The create team membership API fails if an invalid email, phone, or name are supplied. We can get rid of all of those params because the we can look up the user by user id and user id should always be available.

![image](https://github.com/utopia-php/migration/assets/1477010/36eccbd0-2cdf-46bd-83e4-d40c732fb202)

Related issue:

* https://github.com/appwrite/appwrite/issues/6175