### PR TITLE
Fix incorrect password algorithm being exported from Appwrite

### DIFF
--- a/src/Migration/Resources/Database/Attributes/IP.php
+++ b/src/Migration/Resources/Database/Attributes/IP.php
@@ -9,9 +9,6 @@ class IP extends Attribute
 {
     protected ?string $default;
 
-    /**
-     * @param  string  $default
-     */
     public function __construct(string $key, Collection $collection, bool $required = false, bool $array = false, string $default = null)
     {
         parent::__construct($key, $collection, $required, $array);

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -321,7 +321,7 @@ class Appwrite extends Source
                     $user['$id'],
                     $user['email'],
                     $user['name'],
-                    $user['password'] ? new Hash($user['password'], $user['hash']) : null,
+                    $user['password'] ? new Hash($user['password'], algorithm: $user['hash']) : null,
                     $user['phone'],
                     $this->calculateTypes($user),
                     $user['labels'] ?? [],


### PR DESCRIPTION
Before the fix, using the playground to export from appwrite shows an incorrect algorithm and salt.

<img width="479" alt="image" src="https://github.com/utopia-php/migration/assets/1477010/320710e3-efb8-4854-ad2d-62c3f4957a9e">

After the fix, using the playground to export from appwrite shows the correct algorithm:

<img width="611" alt="image" src="https://github.com/utopia-php/migration/assets/1477010/4c2b6013-f03a-47ed-b159-cd8b693e639e">

I also tested running a migration and then logging in with the email and password and it worked:

<img width="723" alt="image" src="https://github.com/utopia-php/migration/assets/1477010/b69b6c60-62bf-4e69-b585-8b0475a2f837">
