### PR TITLE
Update deployment report function to only count active deployments

### DIFF
--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -237,7 +237,9 @@ class Appwrite extends Source
                 $report[Resource::TYPE_DEPLOYMENT] = 0;
                 $functions = $functionsClient->list()['functions'];
                 foreach ($functions as $function) {
-                    $report[Resource::TYPE_DEPLOYMENT] += $functionsClient->listDeployments($function['$id'], [Query::limit(1)])['total'];
+                    if (! empty($function['deployment'])) {
+                        $report[Resource::TYPE_DEPLOYMENT] += 1;
+                    }
                 }
             }
 


### PR DESCRIPTION
In the migrations script we currently only migrate active deployments however the report function counts all deployments, this causes a problem where the amount expected to be transferred and the amount actually transferred doesn't align because of this in Appwrite deployment migrations appear to hang when they actually succeed.