### PR TITLE
Fix empty username migrations and fix empty hashes breaking supabase

### DIFF
--- a/bin/MigrationCLI.php
+++ b/bin/MigrationCLI.php
@@ -220,7 +220,7 @@ class MigrationCLI
                     $_ENV['SOURCE_SUPABASE_TEST_ENDPOINT'],
                     $_ENV['SOURCE_SUPABASE_TEST_KEY'],
                     $_ENV['SOURCE_SUPABASE_TEST_HOST'],
-                    $_ENV['SOURCE_SUPABASE_TEST_DATBASE_NAME'],
+                    $_ENV['SOURCE_SUPABASE_TEST_DATABASE_NAME'],
                     $_ENV['SOURCE_SUPABASE_TEST_DATABASE_USER'],
                     $_ENV['SOURCE_SUPABASE_TEST_DATABASE_PASSWORD']
                 );

--- a/src/Migration/Sources/Supabase.php
+++ b/src/Migration/Sources/Supabase.php
@@ -384,7 +384,7 @@ class Supabase extends NHost
             foreach ($users as $user) {
                 $hash = null;
 
-                if (array_key_exists('encrypted_password', $user)) {
+                if (array_key_exists('encrypted_password', $user) && ! empty($user['encrypted_password'])) {
                     $hash = new Hash($user['encrypted_password'], '', Hash::ALGORITHM_BCRYPT);
                 }
 


### PR DESCRIPTION
This is a fix for empty username migrations and empty hashes in Supabase, and has already been merged in 0.6.x but must be brought to main aswell: https://github.com/utopia-php/migration/pull/51