### PR TITLE
Fix missing email exception and phone users being marked as skipped

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2923,7 +2923,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -1072,9 +1072,9 @@ class Appwrite extends Destination
                     $this->users->create(
                         $resource->getId(),
                         $resource->getEmail(),
-                        $resource->getPhone(),
                         null,
-                        $resource->getUsername()
+                        null,
+                        null
                     );
                 }
 

--- a/src/Migration/Resources/Auth/User.php
+++ b/src/Migration/Resources/Auth/User.php
@@ -22,8 +22,8 @@ class User extends Resource
      */
     public function __construct(
         string $id,
-        private readonly string $email = '',
-        private readonly string $username = '',
+        private readonly ?string $email = '',
+        private readonly ?string $username = '',
         private readonly ?Hash $passwordHash = null,
         private readonly ?string $phone = null,
         private readonly array $labels = [],
@@ -88,7 +88,7 @@ class User extends Resource
     /**
      * Get Email
      */
-    public function getEmail(): string
+    public function getEmail(): ?string
     {
         return $this->email;
     }


### PR DESCRIPTION
Currently, email is marked as required in migrations but are not required in Appwrite so migrating users without an email throws an exception and Phone users are being marked as skipped because we create a user with the phone number, then we try to update that user with their own phone number and it returns a 409 conflict marking it as skipped.