### PR TITLE
Fix: Make firebase arrays work correctly

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,20 @@
+name: "CodeQL"
+
+on: [ pull_request ]
+jobs:
+  lint:
+    name: CodeQL
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - run: git checkout HEAD^2
+
+      - name: Run CodeQL
+        run: |
+          docker run --rm -v $PWD:/app composer sh -c \
+          "composer install --profile --ignore-platform-reqs && composer check"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "test": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/pint --test",
         "format": "./vendor/bin/pint",
-        "check": "./vendor/bin/phpstan analyse --level=8 --memory-limit=2G src tests"
+        "check": "./vendor/bin/phpstan analyse --level 2 src tests --memory-limit 2G"
     },
     "require": {
         "php": ">=8.1",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "test": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/pint --test",
         "format": "./vendor/bin/pint",
-        "check": "./vendor/bin/phpstan analyse --level 2 src tests --memory-limit 2G"
+        "check": "./vendor/bin/phpstan analyse --level 3 src tests --memory-limit 2G"
     },
     "require": {
         "php": ">=8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -507,16 +507,16 @@
         },
         {
             "name": "open-telemetry/api",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/api.git",
-                "reference": "74b1a03263be8c5acb578f41da054b4bac3af4a0"
+                "reference": "8b925df3047628968bc5be722468db1b98b82d51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/74b1a03263be8c5acb578f41da054b4bac3af4a0",
-                "reference": "74b1a03263be8c5acb578f41da054b4bac3af4a0",
+                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/8b925df3047628968bc5be722468db1b98b82d51",
+                "reference": "8b925df3047628968bc5be722468db1b98b82d51",
                 "shasum": ""
             },
             "require": {
@@ -573,7 +573,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-01-20T23:35:16+00:00"
+            "time": "2025-02-03T21:49:11+00:00"
         },
         {
             "name": "open-telemetry/context",
@@ -763,16 +763,16 @@
         },
         {
             "name": "open-telemetry/sdk",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sdk.git",
-                "reference": "96aeaee5b7cb8c0bc4af7ff4717b429f2d9f67e1"
+                "reference": "37eec0fe47ddd627911f318f29b6cd48196be0c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/96aeaee5b7cb8c0bc4af7ff4717b429f2d9f67e1",
-                "reference": "96aeaee5b7cb8c0bc4af7ff4717b429f2d9f67e1",
+                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/37eec0fe47ddd627911f318f29b6cd48196be0c0",
+                "reference": "37eec0fe47ddd627911f318f29b6cd48196be0c0",
                 "shasum": ""
             },
             "require": {
@@ -849,24 +849,24 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-01-09T23:17:14+00:00"
+            "time": "2025-01-29T21:40:28+00:00"
         },
         {
             "name": "open-telemetry/sem-conv",
-            "version": "1.27.1",
+            "version": "1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sem-conv.git",
-                "reference": "1dba705fea74bc0718d04be26090e3697e56f4e6"
+                "reference": "4178c9f390da8e4dbca9b181a9d1efd50cf7ee0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/1dba705fea74bc0718d04be26090e3697e56f4e6",
-                "reference": "1dba705fea74bc0718d04be26090e3697e56f4e6",
+                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/4178c9f390da8e4dbca9b181a9d1efd50cf7ee0a",
+                "reference": "4178c9f390da8e4dbca9b181a9d1efd50cf7ee0a",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.0"
             },
             "type": "library",
             "extra": {
@@ -906,7 +906,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2024-08-28T09:20:31+00:00"
+            "time": "2025-02-06T00:21:48+00:00"
         },
         {
             "name": "php-http/discovery",
@@ -2140,16 +2140,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "0.58.4",
+            "version": "0.58.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "ff3fd22e4fe757cc2a78f17169f6dcc45c96d0fe"
+                "reference": "55308014c697639c6cb270cb5a33cc88fc1ef839"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/ff3fd22e4fe757cc2a78f17169f6dcc45c96d0fe",
-                "reference": "ff3fd22e4fe757cc2a78f17169f6dcc45c96d0fe",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/55308014c697639c6cb270cb5a33cc88fc1ef839",
+                "reference": "55308014c697639c6cb270cb5a33cc88fc1ef839",
                 "shasum": ""
             },
             "require": {
@@ -2190,9 +2190,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/0.58.4"
+                "source": "https://github.com/utopia-php/database/tree/0.58.5"
             },
-            "time": "2025-02-05T02:51:02+00:00"
+            "time": "2025-02-10T08:26:52+00:00"
         },
         {
             "name": "utopia-php/dsn",
@@ -2350,16 +2350,16 @@
         },
         {
             "name": "utopia-php/storage",
-            "version": "0.18.8",
+            "version": "0.18.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "84737afa634e6a833fc4f8b0c967553234d3f215"
+                "reference": "1cf455404e8700b3093fd73d74a38d41cdced90c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/84737afa634e6a833fc4f8b0c967553234d3f215",
-                "reference": "84737afa634e6a833fc4f8b0c967553234d3f215",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/1cf455404e8700b3093fd73d74a38d41cdced90c",
+                "reference": "1cf455404e8700b3093fd73d74a38d41cdced90c",
                 "shasum": ""
             },
             "require": {
@@ -2399,9 +2399,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/0.18.8"
+                "source": "https://github.com/utopia-php/storage/tree/0.18.9"
             },
-            "time": "2024-12-04T08:30:35+00:00"
+            "time": "2025-02-11T13:10:40+00:00"
         },
         {
             "name": "utopia-php/system",
@@ -2641,16 +2641,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.1",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
                 "shasum": ""
             },
             "require": {
@@ -2689,7 +2689,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
             },
             "funding": [
                 {
@@ -2697,7 +2697,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T17:47:46+00:00"
+            "time": "2025-02-12T12:17:51+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2952,16 +2952,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.16",
+            "version": "1.12.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9"
+                "reference": "7027b3b0270bf392de0cfba12825979768d728bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e0bb5cb78545aae631220735aa706eac633a6be9",
-                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7027b3b0270bf392de0cfba12825979768d728bf",
+                "reference": "7027b3b0270bf392de0cfba12825979768d728bf",
                 "shasum": ""
             },
             "require": {
@@ -3006,7 +3006,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-21T14:50:05+00:00"
+            "time": "2025-02-07T15:01:57+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3333,16 +3333,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.6",
+            "version": "11.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3c3ae14c90f244cdda95028c3e469028e8d1c02c"
+                "reference": "e1cb706f019e2547039ca2c839898cd5f557ee5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3c3ae14c90f244cdda95028c3e469028e8d1c02c",
-                "reference": "3c3ae14c90f244cdda95028c3e469028e8d1c02c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e1cb706f019e2547039ca2c839898cd5f557ee5d",
+                "reference": "e1cb706f019e2547039ca2c839898cd5f557ee5d",
                 "shasum": ""
             },
             "require": {
@@ -3414,7 +3414,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.7"
             },
             "funding": [
                 {
@@ -3430,7 +3430,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-31T07:03:30+00:00"
+            "time": "2025-02-06T16:10:05+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -943,7 +943,7 @@ class Appwrite extends Destination
                             continue;
                         }
 
-                        /** @var $attribute \Utopia\Database\Document */
+                        /** @var \Utopia\Database\Document $attribute */
                         $found = false;
                         foreach ($collection->getAttribute('attributes', []) as $attribute) {
                             if ($attribute->getAttribute('key') == $key) {

--- a/src/Migration/Resource.php
+++ b/src/Migration/Resource.php
@@ -155,7 +155,7 @@ abstract class Resource implements \JsonSerializable
     }
 
     /**
-     * @returns array<string>
+     * @return array<string>
      */
     public function getPermissions(): array
     {

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -643,7 +643,7 @@ class Appwrite extends Source
 
                 $attributes = $this->cache->get(Attribute::getName());
                 foreach ($attributes as $attribute) {
-                    /** @var Attribute|Relationship $attribute */
+                    /** @var Relationship $attribute */
                     if (
                         $attribute->getCollection()->getId() === $collection->getId() &&
                         $attribute->getType() === Attribute::TYPE_RELATIONSHIP &&
@@ -660,6 +660,7 @@ class Appwrite extends Source
                         $manyToMany[] = $attribute->getKey();
                     }
                 }
+                /** @var Attribute|Relationship $attribute */
 
                 $queries[] = Query::select($selects);
 
@@ -1132,7 +1133,7 @@ class Appwrite extends Source
 
         try {
             if (in_array(Resource::TYPE_BUCKET, $resources)) {
-                $this->exportBuckets($batchSize, true);
+                $this->exportBuckets($batchSize);
             }
         } catch (\Throwable $e) {
             $this->addError(

--- a/src/Migration/Sources/Firebase.php
+++ b/src/Migration/Sources/Firebase.php
@@ -597,7 +597,7 @@ class Firebase extends Source
             $value = $this->calculateValue($field);
 
             if ($documentSchema[$key]->getType() === Attribute::TYPE_STRING && is_array($value)) {
-                $value = array_map(function($item) {
+                $value = array_map(function ($item) {
                     return strval($item);
                 }, $value);
             };

--- a/src/Migration/Sources/Firebase.php
+++ b/src/Migration/Sources/Firebase.php
@@ -275,10 +275,11 @@ class Firebase extends Source
             throw $e;
         }
 
+        $database = new Database('default', 'default');
+        $database->setOriginalId('(default)');
+
         try {
             if (\in_array(Resource::TYPE_DATABASE, $resources)) {
-                $database = new Database('default', 'default');
-                $database->setOriginalId('(default)');
                 $this->callback([$database]);
             }
         } catch (\Throwable $e) {

--- a/src/Migration/Sources/Firebase.php
+++ b/src/Migration/Sources/Firebase.php
@@ -558,13 +558,13 @@ class Firebase extends Source
     private function calculateValue(array $field)
     {
         if (array_key_exists('booleanValue', $field)) {
-            return $field['booleanValue'];
+            return boolval($field['booleanValue']);
         } elseif (array_key_exists('bytesValue', $field)) {
             return $field['bytesValue'];
         } elseif (array_key_exists('doubleValue', $field)) {
-            return (int)$field['doubleValue'];
+            return floatval($field['doubleValue']);
         } elseif (array_key_exists('integerValue', $field)) {
-            return (int)$field['integerValue'];
+            return intval($field['integerValue']);
         } elseif (array_key_exists('mapValue', $field)) {
             return json_encode($field['mapValue']);
         } elseif (array_key_exists('nullValue', $field)) {
@@ -576,7 +576,7 @@ class Firebase extends Source
         } elseif (array_key_exists('timestampValue', $field)) {
             return $field['timestampValue'];
         } elseif (array_key_exists('geoPointValue', $field)) {
-            return [$field['geoPointValue']['latitude'], $field['geoPointValue']['longitude']];
+            return json_encode($field['geoPointValue']);
         } elseif (array_key_exists('arrayValue', $field)) {
             $values = [];
             foreach ($field['arrayValue']['values'] as $value) {

--- a/src/Migration/Sources/Firebase.php
+++ b/src/Migration/Sources/Firebase.php
@@ -115,6 +115,9 @@ class Firebase extends Source
         return parent::call($method, $path, $headers, $params, $responseHeaders);
     }
 
+    /**
+     * @return array<string>
+     */
     public static function getSupportedResources(): array
     {
         return [
@@ -368,7 +371,7 @@ class Firebase extends Source
     /**
      * @throws \Exception
      */
-    private function convertAttribute(Collection $collection, string $key, array $field): Attribute
+    private function convertAttribute(Collection $collection, string $key, array $field, bool $array = false): Attribute
     {
         if (array_key_exists('booleanValue', $field)) {
             return new Boolean(
@@ -376,7 +379,7 @@ class Firebase extends Source
                 $collection,
                 required:false,
                 default: null,
-                array: false,
+                array: $array,
             );
         } elseif (array_key_exists('bytesValue', $field)) {
             return new Text(
@@ -384,7 +387,7 @@ class Firebase extends Source
                 $collection,
                 required: false,
                 default: null,
-                array: false,
+                array: $array,
                 size: 1000000,
             );
         } elseif (array_key_exists('doubleValue', $field)) {
@@ -393,7 +396,7 @@ class Firebase extends Source
                 $collection,
                 required: false,
                 default: null,
-                array: false,
+                array: $array,
             );
         } elseif (array_key_exists('integerValue', $field)) {
             return new Integer(
@@ -401,7 +404,7 @@ class Firebase extends Source
                 $collection,
                 required: false,
                 default: null,
-                array: false,
+                array: $array,
             );
         } elseif (array_key_exists('mapValue', $field)) {
             return new Text(
@@ -409,7 +412,7 @@ class Firebase extends Source
                 $collection,
                 required: false,
                 default: null,
-                array: false,
+                array: $array,
                 size: 1000000,
             );
         } elseif (array_key_exists('nullValue', $field)) {
@@ -418,7 +421,7 @@ class Firebase extends Source
                 $collection,
                 required: false,
                 default: null,
-                array: false,
+                array: $array,
                 size: 1000000,
             );
         } elseif (array_key_exists('referenceValue', $field)) {
@@ -427,7 +430,7 @@ class Firebase extends Source
                 $collection,
                 required: false,
                 default: null,
-                array: false,
+                array: $array,
                 size: 1000000,
             ); //TODO: This should be a reference attribute
         } elseif (array_key_exists('stringValue', $field)) {
@@ -436,7 +439,7 @@ class Firebase extends Source
                 $collection,
                 required: false,
                 default: null,
-                array: false,
+                array: $array,
                 size: 1000000,
             );
         } elseif (array_key_exists('timestampValue', $field)) {
@@ -445,7 +448,7 @@ class Firebase extends Source
                 $collection,
                 required: false,
                 default: null,
-                array: false,
+                array: $array,
             );
         } elseif (array_key_exists('geoPointValue', $field)) {
             return new Text(
@@ -453,7 +456,7 @@ class Firebase extends Source
                 $collection,
                 required: false,
                 default: null,
-                array: false,
+                array: $array,
                 size: 1000000,
             );
         } elseif (array_key_exists('arrayValue', $field)) {
@@ -470,7 +473,7 @@ class Firebase extends Source
 
         foreach ($data['values'] as $field) {
             if (! $previousType) {
-                $previousType = $this->convertAttribute($collection, $key, $field);
+                $previousType = $this->convertAttribute($collection, $key, $field, true);
             } elseif ($previousType->getName() != ($this->convertAttribute($collection, $key, $field))->getName()) {
                 $isSameType = false;
                 break;
@@ -478,11 +481,9 @@ class Firebase extends Source
         }
 
         if ($isSameType) {
-            $previousType->setArray(true);
-
             return $previousType;
         } else {
-            return new Text($key, $collection, false, true, null, 1000000);
+            return new Text($key, $collection, false, true, true, 1000000);
         }
     }
 
@@ -521,7 +522,7 @@ class Firebase extends Source
                     }
                 }
 
-                $documents[] = $this->convertDocument($collection, $document);
+                $documents[] = $this->convertDocument($collection, $document, $documentSchema);
             }
 
             // Transfer Documents
@@ -561,9 +562,9 @@ class Firebase extends Source
         } elseif (array_key_exists('bytesValue', $field)) {
             return $field['bytesValue'];
         } elseif (array_key_exists('doubleValue', $field)) {
-            return $field['doubleValue'];
+            return (int)$field['doubleValue'];
         } elseif (array_key_exists('integerValue', $field)) {
-            return $field['integerValue'];
+            return (int)$field['integerValue'];
         } elseif (array_key_exists('mapValue', $field)) {
             return json_encode($field['mapValue']);
         } elseif (array_key_exists('nullValue', $field)) {
@@ -577,7 +578,11 @@ class Firebase extends Source
         } elseif (array_key_exists('geoPointValue', $field)) {
             return [$field['geoPointValue']['latitude'], $field['geoPointValue']['longitude']];
         } elseif (array_key_exists('arrayValue', $field)) {
-            //TODO:
+            $values = [];
+            foreach ($field['arrayValue']['values'] as $value) {
+                $values[] = $this->calculateValue($value);
+            }
+            return array_values($values);
         } elseif (array_key_exists('referenceValue', $field)) {
             //TODO:
         } else {
@@ -585,11 +590,19 @@ class Firebase extends Source
         }
     }
 
-    private function convertDocument(Collection $collection, array $document): Document
+    private function convertDocument(Collection $collection, array $document, array $documentSchema): Document
     {
         $data = [];
         foreach ($document['fields'] as $key => $field) {
-            $data[$key] = $this->calculateValue($field);
+            $value = $this->calculateValue($field);
+
+            if ($documentSchema[$key]->getType() === Attribute::TYPE_STRING && is_array($value)) {
+                $value = array_map(function($item) {
+                    return strval($item);
+                }, $value);
+            };
+
+            $data[$key] = $value;
         }
 
         $documentId = explode('/', $document['name']);

--- a/src/Migration/Transfer.php
+++ b/src/Migration/Transfer.php
@@ -186,8 +186,8 @@ class Transfer
     public function run(
         array $resources,
         callable $callback,
-        string $rootResourceId = null,
-        string $rootResourceType = null,
+        ?string $rootResourceId = null,
+        ?string $rootResourceType = null,
     ): void {
         // Allows you to push entire groups if you want.
         $computedResources = [];

--- a/src/Migration/Transfer.php
+++ b/src/Migration/Transfer.php
@@ -105,8 +105,6 @@ class Transfer
         $this->source->registerCache($this->cache);
         $this->destination->registerCache($this->cache);
         $this->destination->setSource($source);
-
-        return $this;
     }
 
     public function getStatusCounters(): array
@@ -196,12 +194,14 @@ class Transfer
 
         foreach ($resources as $resource) {
             if (is_array($resource)) {
+                /** @var array<string> $resource */
                 $computedResources = array_merge($computedResources, $resource);
             } else {
                 $computedResources[] = $resource;
             }
         }
 
+        /** @var array<string> $computedResources */
         $computedResources = array_map('strtolower', $computedResources);
 
         if ($rootResourceId !== '') {


### PR DESCRIPTION
A little while ago we removed the setter methods from all of our classes but forgot to update the Firebase adapter for these changes so it broke arrays when migrating documents. This PR fixes that.