### PR TITLE
Fix migration documents status

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -635,16 +635,16 @@
         },
         {
             "name": "open-telemetry/sdk",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sdk.git",
-                "reference": "37eec0fe47ddd627911f318f29b6cd48196be0c0"
+                "reference": "0e7804c176c4b09d95b7985400aa38ce544cb7fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/37eec0fe47ddd627911f318f29b6cd48196be0c0",
-                "reference": "37eec0fe47ddd627911f318f29b6cd48196be0c0",
+                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/0e7804c176c4b09d95b7985400aa38ce544cb7fc",
+                "reference": "0e7804c176c4b09d95b7985400aa38ce544cb7fc",
                 "shasum": ""
             },
             "require": {
@@ -721,7 +721,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-01-29T21:40:28+00:00"
+            "time": "2025-04-08T09:55:41+00:00"
         },
         {
             "name": "open-telemetry/sem-conv",
@@ -1771,16 +1771,16 @@
         },
         {
             "name": "tbachert/spi",
-            "version": "v1.0.2",
+            "version": "v1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nevay/spi.git",
-                "reference": "2ddfaf815dafb45791a61b08170de8d583c16062"
+                "reference": "506a79c98e1a51522e76ee921ccb6c62d52faf3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nevay/spi/zipball/2ddfaf815dafb45791a61b08170de8d583c16062",
-                "reference": "2ddfaf815dafb45791a61b08170de8d583c16062",
+                "url": "https://api.github.com/repos/Nevay/spi/zipball/506a79c98e1a51522e76ee921ccb6c62d52faf3a",
+                "reference": "506a79c98e1a51522e76ee921ccb6c62d52faf3a",
                 "shasum": ""
             },
             "require": {
@@ -1817,9 +1817,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Nevay/spi/issues",
-                "source": "https://github.com/Nevay/spi/tree/v1.0.2"
+                "source": "https://github.com/Nevay/spi/tree/v1.0.3"
             },
-            "time": "2024-10-04T16:36:12+00:00"
+            "time": "2025-04-02T19:38:14+00:00"
         },
         {
             "name": "utopia-php/cache",
@@ -1920,16 +1920,16 @@
         },
         {
             "name": "utopia-php/database",
-            "version": "0.64.0",
+            "version": "0.64.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/database.git",
-                "reference": "3ec66840dc0bcd24ed1c8e0f6d90fd3a61316ff4"
+                "reference": "dc9c4a68c93e8bea2dfaa76d1ba308be539998bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/database/zipball/3ec66840dc0bcd24ed1c8e0f6d90fd3a61316ff4",
-                "reference": "3ec66840dc0bcd24ed1c8e0f6d90fd3a61316ff4",
+                "url": "https://api.github.com/repos/utopia-php/database/zipball/dc9c4a68c93e8bea2dfaa76d1ba308be539998bd",
+                "reference": "dc9c4a68c93e8bea2dfaa76d1ba308be539998bd",
                 "shasum": ""
             },
             "require": {
@@ -1970,9 +1970,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/database/issues",
-                "source": "https://github.com/utopia-php/database/tree/0.64.0"
+                "source": "https://github.com/utopia-php/database/tree/0.64.2"
             },
-            "time": "2025-03-28T01:35:56+00:00"
+            "time": "2025-04-09T07:53:05+00:00"
         },
         {
             "name": "utopia-php/dsn",
@@ -2349,16 +2349,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.21.2",
+            "version": "v1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "370772e7d9e9da087678a0edf2b11b6960e40558"
+                "reference": "7ddfaa6523a675fae5c4123ee38fc6bfb8ee4f36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/370772e7d9e9da087678a0edf2b11b6960e40558",
-                "reference": "370772e7d9e9da087678a0edf2b11b6960e40558",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/7ddfaa6523a675fae5c4123ee38fc6bfb8ee4f36",
+                "reference": "7ddfaa6523a675fae5c4123ee38fc6bfb8ee4f36",
                 "shasum": ""
             },
             "require": {
@@ -2369,9 +2369,9 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.72.0",
+                "friendsofphp/php-cs-fixer": "^3.75.0",
                 "illuminate/view": "^11.44.2",
-                "larastan/larastan": "^3.2.0",
+                "larastan/larastan": "^3.3.1",
                 "laravel-zero/framework": "^11.36.1",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.3",
@@ -2411,7 +2411,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2025-03-14T22:31:42+00:00"
+            "time": "2025-04-08T22:11:45+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3107,16 +3107,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.15",
+            "version": "11.5.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4b6a4ee654e5e0c5e1f17e2f83c0f4c91dee1f9c"
+                "reference": "fd2e863a2995cdfd864fb514b5e0b28b09895b5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b6a4ee654e5e0c5e1f17e2f83c0f4c91dee1f9c",
-                "reference": "4b6a4ee654e5e0c5e1f17e2f83c0f4c91dee1f9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fd2e863a2995cdfd864fb514b5e0b28b09895b5c",
+                "reference": "fd2e863a2995cdfd864fb514b5e0b28b09895b5c",
                 "shasum": ""
             },
             "require": {
@@ -3188,7 +3188,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.17"
             },
             "funding": [
                 {
@@ -3204,7 +3204,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-23T16:02:11+00:00"
+            "time": "2025-04-08T07:59:11+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/src/Migration/Cache.php
+++ b/src/Migration/Cache.php
@@ -115,6 +115,24 @@ class Cache
      */
     public function remove(Resource $resource): void
     {
+        // if document resource we need to reduce the status counter
+        if ($resource->getName() === Resource::TYPE_DOCUMENT) {
+            $name = $resource->getName();
+            $status = $resource->getStatus();
+
+            if (isset($this->cache[$name][$status]) && is_int($this->cache[$name][$status])) {
+                $curStatusCounter = max($this->cache[$name][$status] - 1, 0);
+
+                if ($curStatusCounter === 0) {
+                    unset($this->cache[$name][$status]);
+                    return;
+                }
+
+                $this->cache[$name][$status] = $curStatusCounter;
+            }
+
+            return;
+        }
         if (! in_array($resource, $this->cache[$resource->getName()])) {
             throw new \Exception('Resource does not exist in cache');
         }

--- a/src/Migration/Cache.php
+++ b/src/Migration/Cache.php
@@ -13,7 +13,7 @@ use Utopia\Migration\Resources\Storage\File;
 class Cache
 {
     /**
-     * @var array<string, array<string, Resource>> $cache
+     * @var array<string, array<string, Resource|int>> $cache
      */
     protected array $cache = [];
 
@@ -75,12 +75,17 @@ class Cache
      */
     public function update(Resource $resource): void
     {
-        if (! in_array($resource->getName(), $this->cache)) {
-            $this->add($resource);
+        if ($resource->getName() == Resource::TYPE_DOCUMENT) {
+            $status = $resource->getStatus();
+            if (!isset($this->cache[$resource->getName()][$status])) {
+                $this->cache[$resource->getName()][$status] = 0;
+            }
+            $this->cache[$resource->getName()][$status]++;
+            return;
         }
 
-        if ($resource->getName() == Resource::TYPE_DOCUMENT) {
-            return;
+        if (! in_array($resource->getName(), $this->cache)) {
+            $this->add($resource);
         }
 
         $this->cache[$resource->getName()][$resource->getInternalId()] = $resource;

--- a/src/Migration/Cache.php
+++ b/src/Migration/Cache.php
@@ -30,14 +30,6 @@ class Cache
      */
     public function add(Resource $resource): void
     {
-        // if documents then storing the status counter only
-        if ($resource->getName() == Resource::TYPE_DOCUMENT) {
-            $status = $resource->getStatus();
-            $documentId = $resource->getInternalId();
-            $this->cache[$resource->getName()][$documentId] = $status;
-            return;
-        }
-
         if (! $resource->getInternalId()) {
             $resourceId = uniqid();
             if (isset($this->cache[$resource->getName()][$resourceId])) {
@@ -45,6 +37,13 @@ class Cache
                 // todo: $resourceId is not used?
             }
             $resource->setInternalId(uniqid());
+        }
+
+        if ($resource->getName() == Resource::TYPE_DOCUMENT) {
+            $status = $resource->getStatus();
+            $documentId = $resource->getInternalId();
+            $this->cache[$resource->getName()][$documentId] = $status;
+            return;
         }
 
         if ($resource->getName() == Resource::TYPE_FILE || $resource->getName() == Resource::TYPE_DEPLOYMENT) {

--- a/src/Migration/Cache.php
+++ b/src/Migration/Cache.php
@@ -33,7 +33,9 @@ class Cache
         // if documents then storing the status counter only
         if ($resource->getName() == Resource::TYPE_DOCUMENT) {
             $status = $resource->getStatus();
-            $this->cache[$resource->getName()][$status] = 0;
+            if (!isset($this->cache[$resource->getName()][$status]) || !is_int($this->cache[$resource->getName()][$status])) {
+                $this->cache[$resource->getName()][$status] = 0;
+            }
             return;
         }
 

--- a/src/Migration/Cache.php
+++ b/src/Migration/Cache.php
@@ -78,16 +78,21 @@ class Cache
      */
     public function update(Resource $resource): void
     {
-        if (! in_array($resource->getName(), $this->cache)) {
-            $this->add($resource);
-        }
         // if documents then updating the status counter only
         if ($resource->getName() == Resource::TYPE_DOCUMENT) {
             $status = $resource->getStatus();
+            $name = $resource->getName();
+            if (!isset($this->cache[$name][$status])) {
+                $this->add($resource);
+            }
             if (is_int($this->cache[$resource->getName()][$status])) {
                 $this->cache[$resource->getName()][$status]++;
-                return;
             }
+            return;
+        }
+
+        if (! in_array($resource->getName(), $this->cache)) {
+            $this->add($resource);
         }
 
         $this->cache[$resource->getName()][$resource->getInternalId()] = $resource;

--- a/src/Migration/Cache.php
+++ b/src/Migration/Cache.php
@@ -30,6 +30,13 @@ class Cache
      */
     public function add(Resource $resource): void
     {
+        // if documents then storing the status counter only
+        if ($resource->getName() == Resource::TYPE_DOCUMENT) {
+            $status = $resource->getStatus();
+            $this->cache[$resource->getName()][$status] = 0;
+            return;
+        }
+
         if (! $resource->getInternalId()) {
             $resourceId = uniqid();
             if (isset($this->cache[$resource->getName()][$resourceId])) {
@@ -42,10 +49,6 @@ class Cache
         if ($resource->getName() == Resource::TYPE_FILE || $resource->getName() == Resource::TYPE_DEPLOYMENT) {
             /** @var File|Deployment $resource */
             $resource->setData(''); // Prevent Memory Leak
-        }
-
-        if ($resource->getName() == Resource::TYPE_DOCUMENT) {
-            return;
         }
 
         $this->cache[$resource->getName()][$resource->getInternalId()] = $resource;
@@ -75,17 +78,16 @@ class Cache
      */
     public function update(Resource $resource): void
     {
-        if ($resource->getName() == Resource::TYPE_DOCUMENT) {
-            $status = $resource->getStatus();
-            if (!isset($this->cache[$resource->getName()][$status])) {
-                $this->cache[$resource->getName()][$status] = 0;
-            }
-            $this->cache[$resource->getName()][$status]++;
-            return;
-        }
-
         if (! in_array($resource->getName(), $this->cache)) {
             $this->add($resource);
+        }
+        // if documents then updating the status counter only
+        if ($resource->getName() == Resource::TYPE_DOCUMENT) {
+            $status = $resource->getStatus();
+            if (is_int($this->cache[$resource->getName()][$status])) {
+                $this->cache[$resource->getName()][$status]++;
+                return;
+            }
         }
 
         $this->cache[$resource->getName()][$resource->getInternalId()] = $resource;

--- a/src/Migration/Transfer.php
+++ b/src/Migration/Transfer.php
@@ -129,8 +129,9 @@ class Transfer
                 }
             }
         }
-
-        foreach ($this->cache->getAll() as $resources) {
+        // document resources are having status counter inside the cache
+        foreach ($this->cache->getAll() as $resourceType => $resources) {
+            if($resourceType == Resource::TYPE_DOCUMENT) continue;
             foreach ($resources as $resource) {
                 if (isset($status[$resource->getName()])) {
                     $status[$resource->getName()][$resource->getStatus()]++;
@@ -140,6 +141,20 @@ class Transfer
                 }
             }
         }
+
+        if (isset($this->cache->getAll()[Resource::TYPE_DOCUMENT])) {
+            $documentsStatus = $this->cache->getAll()[Resource::TYPE_DOCUMENT];
+            $status[Resource::TYPE_DOCUMENT] = $documentsStatus;
+        } else {
+            $status[Resource::TYPE_DOCUMENT] = [];
+        }
+        // merging other statuses to the document resource if not present
+        $allDocumentStatus = [Resource::STATUS_PENDING,Resource::STATUS_SUCCESS,Resource::STATUS_ERROR,Resource::STATUS_SKIPPED,Resource::STATUS_PROCESSING,Resource::STATUS_WARNING];
+        foreach ($allDocumentStatus as $statusValue) {
+            if(!isset($status[Resource::TYPE_DOCUMENT][$statusValue])) {
+                $status[Resource::TYPE_DOCUMENT][$statusValue] = 0;
+        }
+    }
 
         // Process Destination Errors
         foreach ($this->destination->getErrors() as $error) {

--- a/src/Migration/Transfer.php
+++ b/src/Migration/Transfer.php
@@ -131,7 +131,9 @@ class Transfer
         }
         // document resources are having status counter inside the cache
         foreach ($this->cache->getAll() as $resourceType => $resources) {
-            if($resourceType == Resource::TYPE_DOCUMENT) continue;
+            if ($resourceType == Resource::TYPE_DOCUMENT) {
+                continue;
+            }
             foreach ($resources as $resource) {
                 if (isset($status[$resource->getName()])) {
                     $status[$resource->getName()][$resource->getStatus()]++;
@@ -151,10 +153,10 @@ class Transfer
         // merging other statuses to the document resource if not present
         $allDocumentStatus = [Resource::STATUS_PENDING,Resource::STATUS_SUCCESS,Resource::STATUS_ERROR,Resource::STATUS_SKIPPED,Resource::STATUS_PROCESSING,Resource::STATUS_WARNING];
         foreach ($allDocumentStatus as $statusValue) {
-            if(!isset($status[Resource::TYPE_DOCUMENT][$statusValue])) {
+            if (!isset($status[Resource::TYPE_DOCUMENT][$statusValue])) {
                 $status[Resource::TYPE_DOCUMENT][$statusValue] = 0;
+            }
         }
-    }
 
         // Process Destination Errors
         foreach ($this->destination->getErrors() as $error) {

--- a/src/Migration/Transfer.php
+++ b/src/Migration/Transfer.php
@@ -281,6 +281,9 @@ class Transfer
         $cache = $this->cache->getAll();
 
         foreach ($cache as $type => $resources) {
+            if ($type === Resource::TYPE_DOCUMENT) {
+                continue;
+            }
             foreach ($resources as $resource) {
                 if ($statusLevel && $resource->getStatus() !== $statusLevel) {
                     continue;

--- a/src/Migration/Transfer.php
+++ b/src/Migration/Transfer.php
@@ -129,25 +129,24 @@ class Transfer
                 }
             }
         }
-        
+
         foreach ($this->cache->getAll() as $resourceType => $resources) {
-            foreach ($resources as $resourceId => $resource) {
+            foreach ($resources as $resource) {
                 if ($resourceType === Resource::TYPE_DOCUMENT && is_string($resource)) {
                     $documentStatus = $resource;
                     $status[$resourceType][$documentStatus]++;
-                    
-                    if ($documentStatus === 'pending' && $status[$resourceType]['pending'] > 0) {
+
+                    if ($status[$resourceType]['pending'] > 0) {
                         $status[$resourceType]['pending']--;
                     }
-        
-                    continue; // Skip to next iteration
+
+                    continue;
                 }
-        
-                // For all other non-document resources
+
                 if (isset($status[$resource->getName()])) {
                     $status[$resource->getName()][$resource->getStatus()]++;
-        
-                    if ($resource->getStatus() === 'pending' && $status[$resource->getName()]['pending'] > 0) {
+
+                    if ($status[$resource->getName()]['pending'] > 0) {
                         $status[$resource->getName()]['pending']--;
                     }
                 }
@@ -270,46 +269,46 @@ class Transfer
      * @param  string  $statusLevel If no status level is provided, all status types will be returned.
      * @return array<array<string, mixed>>
      */
-public function getReport(string $statusLevel = ''): array
-{
-    $report = [];
-    $cache = $this->cache->getAll();
+    public function getReport(string $statusLevel = ''): array
+    {
+        $report = [];
+        $cache = $this->cache->getAll();
 
-    foreach ($cache as $type => $resources) {
-        foreach ($resources as $id => $resource) {
-            if ($type === Resource::TYPE_DOCUMENT && is_string($resource)) {
-                if ($statusLevel && $resource !== $statusLevel) {
+        foreach ($cache as $type => $resources) {
+            foreach ($resources as $id => $resource) {
+                if ($type === Resource::TYPE_DOCUMENT && is_string($resource)) {
+                    if ($statusLevel && $resource !== $statusLevel) {
+                        continue;
+                    }
+                    // no message for document is stored
+                    $report[] = [
+                        'resource' => $type,
+                        'id' => $id,
+                        'status' => $resource,
+                        'message' => '',
+                    ];
                     continue;
                 }
-                // no message for document is stored
+
+                if (!is_object($resource)) {
+                    continue;
+                }
+
+                if ($statusLevel && $resource->getStatus() !== $statusLevel) {
+                    continue;
+                }
+
                 $report[] = [
                     'resource' => $type,
-                    'id' => $id,
-                    'status' => $resource,
-                    'message' => '',
+                    'id' => $resource->getId(),
+                    'status' => $resource->getStatus(),
+                    'message' => $resource->getMessage(),
                 ];
-                continue;
             }
-
-            if (!is_object($resource)) {
-                continue;
-            }
-
-            if ($statusLevel && $resource->getStatus() !== $statusLevel) {
-                continue;
-            }
-
-            $report[] = [
-                'resource' => $type,
-                'id' => $resource->getId(),
-                'status' => $resource->getStatus(),
-                'message' => $resource->getMessage(),
-            ];
         }
-    }
 
-    return $report;
-}
+        return $report;
+    }
 
     /**
      * @throws \Exception


### PR DESCRIPTION
``Issue
-> Documents are always in pending state despite the documents are migrated and migration is completed
-> Cache ignoring for document type resources

Current fix
-> Currently the structure of the cache for the document is 
```$cache[Resource::TYPE_DOCUMENT][{$documentId}] = {$status}```

Test ran
![Screenshot from 2025-04-10 17-22-11](https://github.com/user-attachments/assets/229502a9-e94f-4a9c-9e35-9743a39ed12e)

Working on appwrite migration dashboard for 5000+ docs

![Screenshot from 2025-04-10 16-07-48](https://github.com/user-attachments/assets/d4c73ece-b398-4bbb-b503-090341efef2e)

