### PR TITLE
index migration issue from 1.6.0 to 1.6.x

### DIFF
--- a/src/Migration/Resources/Database/Index.php
+++ b/src/Migration/Resources/Database/Index.php
@@ -7,11 +7,15 @@ use Utopia\Migration\Transfer;
 
 class Index extends Resource
 {
+    protected static string $timeStampFormatDb = 'Y-m-d H:i:s.v';
     public const TYPE_UNIQUE = 'unique';
 
     public const TYPE_FULLTEXT = 'fulltext';
 
     public const TYPE_KEY = 'key';
+
+    protected string $createdAt;
+    protected string $updatedAt;
 
     /**
      * @param string $id
@@ -21,7 +25,7 @@ class Index extends Resource
      * @param array<string> $attributes
      * @param array<int> $lengths
      * @param array<string> $orders
-     * @param string $createdAt
+     * @param string|null $createdAt
      * @param string $updatedAt
      */
     public function __construct(
@@ -32,10 +36,14 @@ class Index extends Resource
         private readonly array $attributes = [],
         private readonly array $lengths = [],
         private readonly array $orders = [],
-        protected string $createdAt = '',
-        protected string $updatedAt = '',
+        ?string $createdAt = null,
+        ?string $updatedAt = null,
     ) {
         $this->id = $id;
+        $date = new \DateTime();
+        $now = $date->format(self::$timeStampFormatDb);
+        $this->$createdAt = $createdAt ?? $now;
+        $this->$updatedAt = $updatedAt ?? $now;
     }
 
     /**

--- a/src/Migration/Resources/Database/Index.php
+++ b/src/Migration/Resources/Database/Index.php
@@ -32,8 +32,8 @@ class Index extends Resource
         private readonly array $attributes = [],
         private readonly array $lengths = [],
         private readonly array $orders = [],
-        protected string $createdAt = "",
-        protected string $updatedAt = "",
+        protected string $createdAt = '',
+        protected string $updatedAt = '',
     ) {
         $this->id = $id;
     }

--- a/src/Migration/Resources/Database/Index.php
+++ b/src/Migration/Resources/Database/Index.php
@@ -7,15 +7,11 @@ use Utopia\Migration\Transfer;
 
 class Index extends Resource
 {
-    protected static string $timeStampFormatDb = 'Y-m-d H:i:s.v';
     public const TYPE_UNIQUE = 'unique';
 
     public const TYPE_FULLTEXT = 'fulltext';
 
     public const TYPE_KEY = 'key';
-
-    protected string $createdAt;
-    protected string $updatedAt;
 
     /**
      * @param string $id
@@ -25,7 +21,7 @@ class Index extends Resource
      * @param array<string> $attributes
      * @param array<int> $lengths
      * @param array<string> $orders
-     * @param string|null $createdAt
+     * @param string $createdAt
      * @param string $updatedAt
      */
     public function __construct(
@@ -36,14 +32,10 @@ class Index extends Resource
         private readonly array $attributes = [],
         private readonly array $lengths = [],
         private readonly array $orders = [],
-        ?string $createdAt = null,
-        ?string $updatedAt = null,
+        protected string $createdAt = "",
+        protected string $updatedAt = "",
     ) {
         $this->id = $id;
-        $date = new \DateTime();
-        $now = $date->format(self::$timeStampFormatDb);
-        $this->$createdAt = $createdAt ?? $now;
-        $this->$updatedAt = $updatedAt ?? $now;
     }
 
     /**

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -11,6 +11,7 @@ use Appwrite\Services\Storage;
 use Appwrite\Services\Teams;
 use Appwrite\Services\Users;
 use Utopia\Database\Database as UtopiaDatabase;
+use Utopia\Database\DateTime as DbDateTime;
 use Utopia\Migration\Exception;
 use Utopia\Migration\Resource;
 use Utopia\Migration\Resources\Auth\Hash;
@@ -921,8 +922,8 @@ class Appwrite extends Source
                         $index['attributes'],
                         [],
                         $index['orders'],
-                        $index['$createdAt'],
-                        $index['$updatedAt'],
+                        $index['$createdAt'] = empty($index['$createdAt']) ? DbDateTime::now() : $index['$createdAt'],
+                        $index['$updatedAt'] = empty($index['$updatedAt']) ? DbDateTime::now() : $index['$updatedAt'],
                     );
                 }
 

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -11,7 +11,7 @@ use Appwrite\Services\Storage;
 use Appwrite\Services\Teams;
 use Appwrite\Services\Users;
 use Utopia\Database\Database as UtopiaDatabase;
-use Utopia\Database\DateTime as DbDateTime;
+use Utopia\Database\DateTime as UtopiaDateTime;
 use Utopia\Migration\Exception;
 use Utopia\Migration\Resource;
 use Utopia\Migration\Resources\Auth\Hash;
@@ -922,8 +922,8 @@ class Appwrite extends Source
                         $index['attributes'],
                         [],
                         $index['orders'],
-                        $index['$createdAt'] = empty($index['$createdAt']) ? DbDateTime::now() : $index['$createdAt'],
-                        $index['$updatedAt'] = empty($index['$updatedAt']) ? DbDateTime::now() : $index['$updatedAt'],
+                        $index['$createdAt'] = empty($index['$createdAt']) ? UtopiaDateTime::now() : $index['$createdAt'],
+                        $index['$updatedAt'] = empty($index['$updatedAt']) ? UtopiaDateTime::now() : $index['$updatedAt'],
                     );
                 }
 


### PR DESCRIPTION
We dont have createdAt and updatedAt in 1.6.0 appwrite so during the migration they are turning out to be null
So if they are null turning them to current timestamp
https://linear.app/appwrite/issue/DAT-498/failed-self-hosted-migration