### PR TITLE
Optimize reports fetching

### DIFF
--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -1374,7 +1374,7 @@ class Appwrite extends Source
                 $function['events'],
                 $function['schedule'],
                 $function['timeout'],
-                $function['deploymentId'],
+                $function['deploymentId'] ?? '',
                 $function['entrypoint']
             );
 

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -205,7 +205,7 @@ class Appwrite extends Source
             $resources
         ));
 
-        $pageLimit = 20;
+        $pageLimit = 25;
         $teams = ['total' => 0, 'teams' => []];
 
         if (\in_array(Resource::TYPE_USER, $resources)) {
@@ -283,7 +283,7 @@ class Appwrite extends Source
             ])['total'];
         }
 
-        $pageLimit = 20;
+        $pageLimit = 25;
 
         if (\in_array(Resource::TYPE_FILE, $resources)) {
             $report[Resource::TYPE_FILE] = 0;
@@ -336,7 +336,7 @@ class Appwrite extends Source
 
     private function reportFunctions(array $resources, array &$report): void
     {
-        $pageLimit = 20;
+        $pageLimit = 25;
         $needVarsOrDeployments = (
             \in_array(Resource::TYPE_DEPLOYMENT, $resources) ||
             \in_array(Resource::TYPE_ENVIRONMENT_VARIABLE, $resources)


### PR DESCRIPTION
This PR does the following in order to optimize the reports fetching from Appwrite source -
1. Use appropriate queries to get only the data we want - `Query.limit(1)` when we just need the `total`.
2. Use pagination in order to not miss any data counts for reports because by default there's info about 25 only.
3. Use data from top level if the inner level needs some info which can already be available at the parent level. Example - Vars from functions, or attributes, indexes from collections, etc.

---

Benchmark Datasets

| Dataset       | Users  | Databases | Tables | Rows   | Columns | Functions | Deployments |
|---------------|--------|-----------|--------|--------|---------|-----------|-------------|
| Prodn Small Dataset | 625    | 1         | 1      | 46     | 2       | 1         | 1           |
| Local Large Dataset | 7,000+ | 10        | 250    | 62,492 | 1,250   | 1         | 1           |

---

Benchmark Results

<img width="2400" height="1600" alt="image" src="https://github.com/user-attachments/assets/93d0556d-7e37-421e-b659-fef7a80c329a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency and consistency of resource counting by introducing consistent pagination and reducing redundant API calls when fetching users, teams, memberships, storage buckets, files, functions, and related data.
  * Optimized table, column, and index counting by utilizing paginated fetches and direct data access, minimizing unnecessary API requests.
* **Bug Fixes**
  * Prevented potential errors when accessing deployment IDs in function exports by adding a safe fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->