### PR TITLE
updated migration fallback to legacy

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -337,7 +337,7 @@ class Appwrite extends Destination
             '$createdAt' => $resource->getCreatedAt(),
             '$updatedAt' => $resource->getUpdatedAt(),
             'originalId' => empty($resource->getOriginalId()) ? null : $resource->getOriginalId(),
-            'type' => empty($resource->getType()) ? 'sql' : $resource->getType(),
+            'type' => empty($resource->getType()) ? 'legacy' : $resource->getType(),
         ]));
 
         $resource->setSequence($database->getSequence());

--- a/src/Migration/Resources/Database/Database.php
+++ b/src/Migration/Resources/Database/Database.php
@@ -46,7 +46,7 @@ class Database extends Resource
             updatedAt: $array['updatedAt'] ?? '',
             enabled: $array['enabled'] ?? true,
             originalId: $array['originalId'] ?? '',
-            type: $array['type'] ?? 'sql',
+            type: $array['type'] ?? 'legacy',
         );
     }
 

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -725,7 +725,7 @@ class Appwrite extends Source
                     $database['name'],
                     $database['$createdAt'],
                     $database['$updatedAt'],
-                    type: $database['type'] ?? 'sql'
+                    type: $database['type'] ?? 'legacy'
                 );
 
                 $databases[] = $newDatabase;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the default value for database type from 'sql' to 'legacy' when the type is not specified during database creation, import, or export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->