### PR TITLE
removed duplicate calls to export buckets

### DIFF
--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -1159,22 +1159,6 @@ class Appwrite extends Source
                 )
             );
         }
-
-        try {
-            if (in_array(Resource::TYPE_BUCKET, $resources)) {
-                $this->exportBuckets($batchSize);
-            }
-        } catch (\Throwable $e) {
-            $this->addError(
-                new Exception(
-                    Resource::TYPE_BUCKET,
-                    Transfer::GROUP_STORAGE,
-                    message: $e->getMessage(),
-                    code: $e->getCode(),
-                    previous: $e
-                )
-            );
-        }
     }
 
     /**


### PR DESCRIPTION
removed duplicate calls to export buckets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could trigger bucket exports twice during Appwrite migrations when bucket resources were included. Buckets and files are now exported exactly once, preventing duplicate data and reducing potential errors.
  * Streamlined the export flow without changing behavior for file exports or other resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->