### PR TITLE
feat: migrate push targets with user resources

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -1745,8 +1745,13 @@ class Appwrite extends Destination
                 case 'push':
                     $userDoc ??= $this->dbForProject->getDocument('users', $userId);
 
+                    $createdAt = $this->normalizeDateTime($target['$createdAt'] ?? null);
+                    $updatedAt = $this->normalizeDateTime($target['$updatedAt'] ?? null, $createdAt);
+
                     $this->dbForProject->createDocument('targets', new UtopiaDocument([
                         '$id' => $target['$id'],
+                        '$createdAt' => $createdAt,
+                        '$updatedAt' => $updatedAt,
                         '$permissions' => [
                             Permission::read(Role::user($userId)),
                             Permission::update(Role::user($userId)),
@@ -1901,9 +1906,16 @@ class Appwrite extends Destination
             Query::isNull('providerInternalId'),
         ]);
 
+        $userIds = [];
+
         foreach ($targets as $target) {
             $target->setAttribute('providerInternalId', $provider->getSequence());
             $this->dbForProject->updateDocument('targets', $target->getId(), $target);
+            $userIds[$target->getAttribute('userId')] = true;
+        }
+
+        foreach (array_keys($userIds) as $userId) {
+            $this->dbForProject->purgeCachedDocument('users', $userId);
         }
     }
 

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -1264,6 +1264,10 @@ class Appwrite extends Destination
                     $this->users->updateLabels($resource->getId(), $resource->getLabels());
                 }
 
+                if (!empty($resource->getTargets())) {
+                    $this->importUserTargets($resource->getId(), $resource->getTargets());
+                }
+
                 break;
             case Resource::TYPE_TEAM:
                 /** @var Team $resource */
@@ -1723,6 +1727,49 @@ class Appwrite extends Destination
     }
 
     /**
+     * Import user targets not auto-created by the server (e.g. push).
+     * providerInternalId is resolved later in createProvider().
+     *
+     * @param array<array<string, mixed>> $targets
+     */
+    protected function importUserTargets(string $userId, array $targets): void
+    {
+        $userDoc = null;
+
+        foreach ($targets as $target) {
+            switch ($target['providerType'] ?? '') {
+                case 'email':
+                case 'sms':
+                    // Auto-created by the server when a user is created with an email/phone
+                    break;
+                case 'push':
+                    $userDoc ??= $this->dbForProject->getDocument('users', $userId);
+
+                    $this->dbForProject->createDocument('targets', new UtopiaDocument([
+                        '$id' => $target['$id'],
+                        '$permissions' => [
+                            Permission::read(Role::user($userId)),
+                            Permission::update(Role::user($userId)),
+                            Permission::delete(Role::user($userId)),
+                        ],
+                        'userId' => $userId,
+                        'userInternalId' => $userDoc->getSequence(),
+                        'providerType' => $target['providerType'],
+                        'providerId' => $target['providerId'] ?? null,
+                        'identifier' => $target['identifier'],
+                        'name' => $target['name'] ?? null,
+                        'expired' => $target['expired'] ?? false,
+                    ]));
+                    break;
+            }
+        }
+
+        if ($userDoc !== null) {
+            $this->dbForProject->purgeCachedDocument('users', $userId);
+        }
+    }
+
+    /**
      * @throws AppwriteException
      * @throws \Exception
      */
@@ -1845,6 +1892,19 @@ class Appwrite extends Destination
             ),
             default => throw new \Exception('Unknown provider: ' . $resource->getProvider()),
         };
+
+        // Resolve providerInternalId for push targets that were written during GROUP_AUTH
+        // before the provider existed on the destination.
+        $provider = $this->dbForProject->getDocument('providers', $id);
+        $targets = $this->dbForProject->find('targets', [
+            Query::equal('providerId', [$id]),
+            Query::isNull('providerInternalId'),
+        ]);
+
+        foreach ($targets as $target) {
+            $target->setAttribute('providerInternalId', $provider->getSequence());
+            $this->dbForProject->updateDocument('targets', $target->getId(), $target);
+        }
     }
 
     /**

--- a/src/Migration/Resources/Auth/User.php
+++ b/src/Migration/Resources/Auth/User.php
@@ -19,6 +19,7 @@ class User extends Resource
      * @param bool $phoneVerified
      * @param bool $disabled
      * @param array<string, mixed> $preferences
+     * @param array<array<string, mixed>> $targets
      */
     public function __construct(
         string $id,
@@ -31,7 +32,8 @@ class User extends Resource
         private readonly bool $emailVerified = false,
         private readonly bool $phoneVerified = false,
         private readonly bool $disabled = false,
-        private readonly array $preferences = []
+        private readonly array $preferences = [],
+        private readonly array $targets = [],
     ) {
         $this->id = $id;
     }
@@ -53,7 +55,8 @@ class User extends Resource
             $array['emailVerified'] ?? false,
             $array['phoneVerified'] ?? false,
             $array['disabled'] ?? false,
-            $array['preferences'] ?? []
+            $array['preferences'] ?? [],
+            $array['targets'] ?? [],
         );
     }
 
@@ -74,6 +77,7 @@ class User extends Resource
             'phoneVerified' => $this->phoneVerified,
             'disabled' => $this->disabled,
             'preferences' => $this->preferences,
+            'targets' => $this->targets,
         ];
     }
 
@@ -171,5 +175,15 @@ class User extends Resource
     public function getPreferences(): array
     {
         return $this->preferences;
+    }
+
+    /**
+     * Get Targets
+     *
+     * @return array<array<string, mixed>>
+     */
+    public function getTargets(): array
+    {
+        return $this->targets;
     }
 }

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -617,6 +617,7 @@ class Appwrite extends Source
                     $user['phoneVerification'] ?? false,
                     !$user['status'],
                     $user['prefs'] ?? [],
+                    $user['targets'] ?? [],
                 );
 
                 $lastDocument = $user['$id'];


### PR DESCRIPTION
## Summary
- Add `targets` property to `User` resource to carry push target data during migration
- Write push targets during `GROUP_AUTH` (provider may not exist yet on destination)
- Resolve `providerInternalId` on targets after provider creation in `GROUP_MESSAGING`
- Skip email/SMS targets (auto-created by server when user has email/phone)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User push notification targets are now migrated with user accounts, preserving notification settings during migrations.

* **Bug Fixes**
  * Targets created before a provider existed are retroactively linked once the provider is available, and affected user cache is refreshed to ensure consistent notification state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->