### PR TITLE
Add backup policy migration support

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -169,6 +169,9 @@ class Appwrite extends Destination
             Resource::TYPE_SITE,
             Resource::TYPE_SITE_DEPLOYMENT,
             Resource::TYPE_SITE_VARIABLE,
+
+            // Backups
+            Resource::TYPE_BACKUP_POLICY,
         ];
     }
 
@@ -325,6 +328,7 @@ class Appwrite extends Destination
                     Transfer::GROUP_FUNCTIONS => $this->importFunctionResource($resource),
                     Transfer::GROUP_MESSAGING => $this->importMessagingResource($resource),
                     Transfer::GROUP_SITES => $this->importSiteResource($resource),
+                    Transfer::GROUP_BACKUPS => $this->importBackupResource($resource),
                     default => throw new \Exception('Invalid resource group', Exception::CODE_VALIDATION),
                 };
             } catch (\Throwable $e) {
@@ -1478,6 +1482,13 @@ class Appwrite extends Destination
                 return $this->importDeployment($resource);
         }
 
+        $resource->setStatus(Resource::STATUS_SUCCESS);
+
+        return $resource;
+    }
+
+    public function importBackupResource(Resource $resource): Resource
+    {
         $resource->setStatus(Resource::STATUS_SUCCESS);
 
         return $resource;

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -1489,7 +1489,7 @@ class Appwrite extends Destination
 
     public function importBackupResource(Resource $resource): Resource
     {
-        $resource->setStatus(Resource::STATUS_SUCCESS);
+        $resource->setStatus(Resource::STATUS_SKIPPED);
 
         return $resource;
     }

--- a/src/Migration/Resource.php
+++ b/src/Migration/Resource.php
@@ -75,6 +75,9 @@ abstract class Resource implements \JsonSerializable
 
     public const TYPE_MESSAGE = 'message';
 
+    // Backups
+    public const TYPE_BACKUP_POLICY = 'backup-policy';
+
     // legacy terminologies
     public const TYPE_DOCUMENT = 'document';
     public const TYPE_ATTRIBUTE = 'attribute';
@@ -110,6 +113,7 @@ abstract class Resource implements \JsonSerializable
         self::TYPE_TOPIC,
         self::TYPE_SUBSCRIBER,
         self::TYPE_MESSAGE,
+        self::TYPE_BACKUP_POLICY,
 
         // legacy
         self::TYPE_DOCUMENT,

--- a/src/Migration/Resources/Backups/Policy.php
+++ b/src/Migration/Resources/Backups/Policy.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Utopia\Migration\Resources\Backups;
+
+use Utopia\Migration\Resource;
+use Utopia\Migration\Transfer;
+
+class Policy extends Resource
+{
+    /**
+     * @param string $id
+     * @param string $name
+     * @param array<string> $services
+     * @param int $retention
+     * @param string $schedule
+     * @param bool $enabled
+     * @param string $resourceId
+     * @param string $resourceType
+     */
+    public function __construct(
+        string $id = '',
+        private readonly string $name = '',
+        private readonly array $services = [],
+        private readonly int $retention = 0,
+        private readonly string $schedule = '',
+        private readonly bool $enabled = true,
+        private readonly string $resourceId = '',
+        private readonly string $resourceType = '',
+    ) {
+        $this->id = $id;
+    }
+
+    /**
+     * @param array<string, mixed> $array
+     * @return self
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            $array['id'],
+            $array['name'] ?? '',
+            $array['services'] ?? [],
+            $array['retention'] ?? 0,
+            $array['schedule'] ?? '',
+            $array['enabled'] ?? true,
+            $array['resourceId'] ?? '',
+            $array['resourceType'] ?? '',
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'services' => $this->services,
+            'retention' => $this->retention,
+            'schedule' => $this->schedule,
+            'enabled' => $this->enabled,
+            'resourceId' => $this->resourceId,
+            'resourceType' => $this->resourceType,
+        ];
+    }
+
+    public static function getName(): string
+    {
+        return Resource::TYPE_BACKUP_POLICY;
+    }
+
+    public function getGroup(): string
+    {
+        return Transfer::GROUP_BACKUPS;
+    }
+
+    public function getPolicyName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getServices(): array
+    {
+        return $this->services;
+    }
+
+    public function getRetention(): int
+    {
+        return $this->retention;
+    }
+
+    public function getSchedule(): string
+    {
+        return $this->schedule;
+    }
+
+    public function getEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function getResourceId(): string
+    {
+        return $this->resourceId;
+    }
+
+    public function getResourceType(): string
+    {
+        return $this->resourceType;
+    }
+}

--- a/src/Migration/Source.php
+++ b/src/Migration/Source.php
@@ -46,6 +46,11 @@ abstract class Source extends Target
         return static::$defaultBatchSize;
     }
 
+    public function getBackupsBatchSize(): int
+    {
+        return static::$defaultBatchSize;
+    }
+
     /**
      * @param array<Resource> $resources
      * @return void
@@ -109,6 +114,7 @@ abstract class Source extends Target
                 Transfer::GROUP_FUNCTIONS => Transfer::GROUP_FUNCTIONS_RESOURCES,
                 Transfer::GROUP_MESSAGING => Transfer::GROUP_MESSAGING_RESOURCES,
                 Transfer::GROUP_SITES => Transfer::GROUP_SITES_RESOURCES,
+                Transfer::GROUP_BACKUPS => Transfer::GROUP_BACKUPS_RESOURCES,
             ];
 
             foreach ($mapping as $group => $resources) {
@@ -142,6 +148,9 @@ abstract class Source extends Target
                     break;
                 case Transfer::GROUP_SITES:
                     $this->exportGroupSites($this->getSitesBatchSize(), $resources);
+                    break;
+                case Transfer::GROUP_BACKUPS:
+                    $this->exportGroupBackups($this->getBackupsBatchSize(), $resources);
                     break;
             }
         }
@@ -194,4 +203,12 @@ abstract class Source extends Target
      * @param array<string> $resources Resources to export
      */
     abstract protected function exportGroupSites(int $batchSize, array $resources): void;
+
+    /**
+     * Export Backups Group
+     *
+     * @param int $batchSize
+     * @param array<string> $resources Resources to export
+     */
+    abstract protected function exportGroupBackups(int $batchSize, array $resources): void;
 }

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -200,6 +200,9 @@ class Appwrite extends Source
             Resource::TYPE_SITE_DEPLOYMENT,
             Resource::TYPE_SITE_VARIABLE,
 
+            // Backups
+            Resource::TYPE_BACKUP_POLICY,
+
             // Settings
         ];
     }
@@ -239,6 +242,7 @@ class Appwrite extends Source
             $this->reportFunctions($resources, $report, $resourceIds);
             $this->reportMessaging($resources, $report, $resourceIds);
             $this->reportSites($resources, $report, $resourceIds);
+            $this->reportBackups($resources, $report, $resourceIds);
 
             $report['version'] = $this->call(
                 'GET',
@@ -1416,6 +1420,18 @@ class Appwrite extends Source
                 code: (int) $e->getCode() ?: Exception::CODE_INTERNAL,
                 previous: $e
             ));
+        }
+    }
+
+    protected function exportGroupBackups(int $batchSize, array $resources): void
+    {
+        // No-op: backup policies are Cloud-only
+    }
+
+    protected function reportBackups(array $resources, array &$report, array $resourceIds = []): void
+    {
+        if (\in_array(Resource::TYPE_BACKUP_POLICY, $resources)) {
+            $report[Resource::TYPE_BACKUP_POLICY] = 0;
         }
     }
 

--- a/src/Migration/Sources/CSV.php
+++ b/src/Migration/Sources/CSV.php
@@ -429,6 +429,11 @@ class CSV extends Source
         throw new \Exception('Not Implemented');
     }
 
+    protected function exportGroupBackups(int $batchSize, array $resources): void
+    {
+        throw new \Exception('Not Implemented');
+    }
+
     /**
      * @param callable(resource $stream, string $delimiter): void $callback
      * @return void

--- a/src/Migration/Sources/Firebase.php
+++ b/src/Migration/Sources/Firebase.php
@@ -818,4 +818,9 @@ class Firebase extends Source
     {
         throw new \Exception('Not implemented');
     }
+
+    protected function exportGroupBackups(int $batchSize, array $resources): void
+    {
+        throw new \Exception('Not implemented');
+    }
 }

--- a/src/Migration/Sources/JSON.php
+++ b/src/Migration/Sources/JSON.php
@@ -209,6 +209,11 @@ class JSON extends Source
         throw new \Exception('Not Implemented');
     }
 
+    protected function exportGroupBackups(int $batchSize, array $resources): void
+    {
+        throw new \Exception('Not Implemented');
+    }
+
     /**
      * @throws \Exception
      */

--- a/src/Migration/Sources/NHost.php
+++ b/src/Migration/Sources/NHost.php
@@ -951,4 +951,9 @@ class NHost extends Source
     {
         throw new \Exception('Not Implemented');
     }
+
+    protected function exportGroupBackups(int $batchSize, array $resources): void
+    {
+        throw new \Exception('Not Implemented');
+    }
 }

--- a/src/Migration/Transfer.php
+++ b/src/Migration/Transfer.php
@@ -26,6 +26,8 @@ class Transfer
 
     public const GROUP_MESSAGING = 'messaging';
 
+    public const GROUP_BACKUPS = 'backups';
+
     public const GROUP_AUTH_RESOURCES = [
         Resource::TYPE_USER,
         Resource::TYPE_TEAM,
@@ -88,6 +90,10 @@ class Transfer
 
     public const GROUP_SETTINGS_RESOURCES = [];
 
+    public const GROUP_BACKUPS_RESOURCES = [
+        Resource::TYPE_BACKUP_POLICY,
+    ];
+
     public const GROUP_MESSAGING_RESOURCES = [
         Resource::TYPE_PROVIDER,
         Resource::TYPE_TOPIC,
@@ -116,6 +122,7 @@ class Transfer
         Resource::TYPE_TOPIC,
         Resource::TYPE_SUBSCRIBER,
         Resource::TYPE_MESSAGE,
+        Resource::TYPE_BACKUP_POLICY,
 
         // legacy
         Resource::TYPE_DOCUMENT,
@@ -399,6 +406,7 @@ class Transfer
                 self::GROUP_DATABASES_VECTOR_DB => array_merge($resources, self::GROUP_VECTORSDB_RESOURCES),
                 self::GROUP_SETTINGS => array_merge($resources, self::GROUP_SETTINGS_RESOURCES),
                 self::GROUP_MESSAGING => array_merge($resources, self::GROUP_MESSAGING_RESOURCES),
+                self::GROUP_BACKUPS => array_merge($resources, self::GROUP_BACKUPS_RESOURCES),
                 default => throw new \Exception('No service group found'),
             };
         }

--- a/tests/Migration/Unit/Adapters/MockSource.php
+++ b/tests/Migration/Unit/Adapters/MockSource.php
@@ -84,6 +84,7 @@ class MockSource extends Source
             Resource::TYPE_TOPIC,
             Resource::TYPE_SUBSCRIBER,
             Resource::TYPE_MESSAGE,
+            Resource::TYPE_BACKUP_POLICY,
 
             // legacy
             Resource::TYPE_DOCUMENT,
@@ -196,6 +197,17 @@ class MockSource extends Source
             }
 
             $this->handleResourceTransfer(Transfer::GROUP_SITES, $resource);
+        }
+    }
+
+    protected function exportGroupBackups(int $batchSize, array $resources): void
+    {
+        foreach (Transfer::GROUP_BACKUPS_RESOURCES as $resource) {
+            if (!\in_array($resource, $resources)) {
+                continue;
+            }
+
+            $this->handleResourceTransfer(Transfer::GROUP_BACKUPS, $resource);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `backup-policy` resource type and `backups` group to the migration framework
- Add `Policy` resource class with properties: id, name, services, retention, schedule, enabled, resourceId, resourceType
- Add no-op stubs in CE source/destination (backup policies are Cloud-only)
- Add `exportGroupBackups` abstract method to `Source` with implementations in all source classes

## Test plan
- [ ] Unit tests for Policy resource serialization
- [ ] E2E test: migrate backup policies between Cloud projects
- [ ] Verify no-op behavior on CE (self-hosted)
- [ ] Verify other migration sources (Firebase, NHost, CSV, JSON) don't break

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backup policy support to the migration system.
  * Backup policies are now a recognized transferable resource type.
  * Sources can export backups and destinations can import backup policies during migrations.
* **Tests**
  * Migration tests updated to include backup policy export paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->