### PR TITLE
fix: Handle missing 'database' key when migrating from Appwrite Cloud

### DIFF
--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -865,7 +865,7 @@ class Appwrite extends Source
                         'createdAt' => $database['$createdAt'],
                         'updatedAt' => $database['$updatedAt'],
                         'type' => $originalType,
-                        'database' => $database['database'],
+                        'database' => $database['database'] ?? null,
                         'enabled' => $database['enabled'] ?? true,
                     ]);
                     $databases[] = $newDatabase;


### PR DESCRIPTION
## Summary

When migrating databases from Appwrite Cloud to a self-hosted Appwrite instance, the migration worker crashes with a PHP warning:
`Warning: Undefined array key "database" in .../Migration/Sources/Appwrite.php on line 868`

### Root Cause

In `exportDatabases()`, the code builds a database object using the raw API response from Appwrite Cloud:

```php
$newDatabase = self::getDatabase($databaseFamilyType, [
    ...
    'database' => $database['database'], // crashes if key absent
    ...
]);
```

Newer versions of the Appwrite Cloud API do not return the internal `database` key in the database listing response. This causes a fatal PHP warning that halts the migration.

### Fix

Updated the logic to use `null` instead of an empty string `''` for the `database` field when it's missing from the source. This is crucial because:

- An empty string `''` causes Appwrite 1.9.0 to attempt parsing an invalid DSN (e.g., `mysql://`), leading to HTTP 500 errors.
- - Using `null` allows Appwrite's internal `getAttribute()` logic to correctly trigger the default fallback to the internal connection pool (e.g., `database_db_main`).
```php
'database' => $database['database'] ?? null,
```

## Testing

Tested successfully by performing a full Cloud to self-hosted migration:
1 database migrated
15 tables migrated
141 columns migrated
11,791 rows migrated
