### PR TITLE
Update utopia-php/storage to 2.* for compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-openssl": "*",
         "appwrite/appwrite": "19.*",
         "utopia-php/database": "5.*",
-        "utopia-php/storage": "0.*",
+        "utopia-php/storage": "2.*",
         "utopia-php/dsn": "0.2.*",
         "halaxa/json-machine": "^1.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21b3b0c90a7d5ac554486cd4e54edfff",
+    "content-hash": "38981f8df096cfbc9dd34487643b7ed6",
     "packages": [
         {
             "name": "appwrite/appwrite",
@@ -2288,54 +2288,6 @@
             "time": "2026-04-20T07:12:46+00:00"
         },
         {
-            "name": "utopia-php/di",
-            "version": "0.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/utopia-php/di.git",
-                "reference": "22490c95f7ac3898ed1c33f1b1b5dd577305ee31"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/di/zipball/22490c95f7ac3898ed1c33f1b1b5dd577305ee31",
-                "reference": "22490c95f7ac3898ed1c33f1b1b5dd577305ee31",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.2",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.5.25",
-                "swoole/ide-helper": "4.8.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Utopia\\": "src/",
-                    "Tests\\E2E\\": "tests/e2e"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A simple and lite library for managing dependency injections",
-            "keywords": [
-                "framework",
-                "http",
-                "php",
-                "upf"
-            ],
-            "support": {
-                "issues": "https://github.com/utopia-php/di/issues",
-                "source": "https://github.com/utopia-php/di/tree/0.1.0"
-            },
-            "time": "2024-08-08T14:35:19+00:00"
-        },
-        {
             "name": "utopia-php/dsn",
             "version": "0.2.1",
             "source": {
@@ -2381,56 +2333,6 @@
                 "source": "https://github.com/utopia-php/dsn/tree/0.2.1"
             },
             "time": "2024-05-07T02:01:25+00:00"
-        },
-        {
-            "name": "utopia-php/framework",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/utopia-php/http.git",
-                "reference": "fc63ec61c720190a5ea5bb484c615145850951e6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/fc63ec61c720190a5ea5bb484c615145850951e6",
-                "reference": "fc63ec61c720190a5ea5bb484c615145850951e6",
-                "shasum": ""
-            },
-            "require": {
-                "ext-swoole": "*",
-                "php": ">=8.0",
-                "utopia-php/servers": "0.1.*"
-            },
-            "require-dev": {
-                "ext-xdebug": "*",
-                "laravel/pint": "^1.2",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.5.25",
-                "swoole/ide-helper": "4.8.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Utopia\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A simple, light and advanced PHP HTTP framework",
-            "keywords": [
-                "framework",
-                "http",
-                "php",
-                "upf"
-            ],
-            "support": {
-                "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/1.0.2"
-            },
-            "time": "2024-09-10T09:04:19+00:00"
         },
         {
             "name": "utopia-php/mongo",
@@ -2547,88 +2449,32 @@
             "time": "2026-02-26T08:42:40+00:00"
         },
         {
-            "name": "utopia-php/servers",
-            "version": "0.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/utopia-php/servers.git",
-                "reference": "fd5c8d32778f265256c1936372a071b944f5ba8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/servers/zipball/fd5c8d32778f265256c1936372a071b944f5ba8a",
-                "reference": "fd5c8d32778f265256c1936372a071b944f5ba8a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0",
-                "utopia-php/di": "0.1.*"
-            },
-            "require-dev": {
-                "laravel/pint": "^0.2.3",
-                "phpstan/phpstan": "^1.8",
-                "phpunit/phpunit": "^9.5.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Utopia\\Servers\\": "src/Servers"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Team Appwrite",
-                    "email": "team@appwrite.io"
-                }
-            ],
-            "description": "A base library for building Utopia style servers.",
-            "keywords": [
-                "framework",
-                "php",
-                "servers",
-                "upf",
-                "utopia"
-            ],
-            "support": {
-                "issues": "https://github.com/utopia-php/servers/issues",
-                "source": "https://github.com/utopia-php/servers/tree/0.1.1"
-            },
-            "time": "2024-09-06T02:25:56+00:00"
-        },
-        {
             "name": "utopia-php/storage",
-            "version": "0.19.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "fdae7bf8d01c1ad735e45ae519bd65970becbde8"
+                "reference": "52d1f89a47165ef0d3deff63043cda182175adfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/fdae7bf8d01c1ad735e45ae519bd65970becbde8",
-                "reference": "fdae7bf8d01c1ad735e45ae519bd65970becbde8",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/52d1f89a47165ef0d3deff63043cda182175adfb",
+                "reference": "52d1f89a47165ef0d3deff63043cda182175adfb",
                 "shasum": ""
             },
             "require": {
-                "ext-brotli": "*",
+                "ext-curl": "*",
                 "ext-fileinfo": "*",
-                "ext-lz4": "*",
-                "ext-snappy": "*",
-                "ext-xz": "*",
+                "ext-simplexml": "*",
                 "ext-zlib": "*",
-                "ext-zstd": "*",
-                "php": ">=8.0",
-                "utopia-php/framework": "1.0.*",
-                "utopia-php/system": "0.9.*"
+                "php": ">=8.1",
+                "utopia-php/system": "0.*.*",
+                "utopia-php/telemetry": "0.2.*",
+                "utopia-php/validators": "0.2.*"
             },
             "require-dev": {
-                "laravel/pint": "1.2.*",
-                "phpunit/phpunit": "^9.3",
-                "vimeo/psalm": "4.0.1"
+                "laravel/pint": "^1.21",
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "autoload": {
@@ -2650,22 +2496,22 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/0.19.2"
+                "source": "https://github.com/utopia-php/storage/tree/2.0.0"
             },
-            "time": "2024-11-06T09:34:30+00:00"
+            "time": "2026-04-27T11:39:32+00:00"
         },
         {
             "name": "utopia-php/system",
-            "version": "0.9.0",
+            "version": "0.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/system.git",
-                "reference": "8e4a7edaf2dfeb4c9524e9f766d27754f2c4b64d"
+                "reference": "7c1669533bb9c285de19191270c8c1439161a78a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/system/zipball/8e4a7edaf2dfeb4c9524e9f766d27754f2c4b64d",
-                "reference": "8e4a7edaf2dfeb4c9524e9f766d27754f2c4b64d",
+                "url": "https://api.github.com/repos/utopia-php/system/zipball/7c1669533bb9c285de19191270c8c1439161a78a",
+                "reference": "7c1669533bb9c285de19191270c8c1439161a78a",
                 "shasum": ""
             },
             "require": {
@@ -2673,7 +2519,7 @@
             },
             "require-dev": {
                 "laravel/pint": "1.13.*",
-                "phpstan/phpstan": "1.10.*",
+                "phpstan/phpstan": "1.12.*",
                 "phpunit/phpunit": "9.6.*"
             },
             "type": "library",
@@ -2706,22 +2552,22 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/system/issues",
-                "source": "https://github.com/utopia-php/system/tree/0.9.0"
+                "source": "https://github.com/utopia-php/system/tree/0.10.1"
             },
-            "time": "2024-10-09T14:44:01+00:00"
+            "time": "2026-03-15T21:07:41+00:00"
         },
         {
             "name": "utopia-php/telemetry",
-            "version": "0.3.0",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/telemetry.git",
-                "reference": "62bbadad03e593b071b8ca63fac2c117c1900991"
+                "reference": "9997ebf59bb77920a7223ad73d834a76b09152c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/telemetry/zipball/62bbadad03e593b071b8ca63fac2c117c1900991",
-                "reference": "62bbadad03e593b071b8ca63fac2c117c1900991",
+                "url": "https://api.github.com/repos/utopia-php/telemetry/zipball/9997ebf59bb77920a7223ad73d834a76b09152c3",
+                "reference": "9997ebf59bb77920a7223ad73d834a76b09152c3",
                 "shasum": ""
             },
             "require": {
@@ -2761,9 +2607,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/telemetry/issues",
-                "source": "https://github.com/utopia-php/telemetry/tree/0.3.0"
+                "source": "https://github.com/utopia-php/telemetry/tree/0.2.0"
             },
-            "time": "2026-04-01T13:52:56+00:00"
+            "time": "2025-12-17T07:56:38+00:00"
         },
         {
             "name": "utopia-php/validators",
@@ -2876,16 +2722,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.29.1",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80"
+                "reference": "e60e2112ee779ce60f253695b273d1646a17d6f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/0770e9b7fafd50d4586881d456d6eb41c9247a80",
-                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/e60e2112ee779ce60f253695b273d1646a17d6f1",
+                "reference": "e60e2112ee779ce60f253695b273d1646a17d6f1",
                 "shasum": ""
             },
             "require": {
@@ -2893,17 +2739,16 @@
                 "ext-mbstring": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "php": "^8.2.0"
+                "php": "^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.95.1",
-                "illuminate/view": "^12.56.0",
-                "larastan/larastan": "^3.9.6",
-                "laravel-zero/framework": "^12.1.0",
-                "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.4.0",
-                "pestphp/pest": "^3.8.6",
-                "shipfastlabs/agent-detector": "^1.1.3"
+                "friendsofphp/php-cs-fixer": "^3.11.0",
+                "illuminate/view": "^9.32.0",
+                "laravel-zero/framework": "^9.2.0",
+                "mockery/mockery": "^1.5.1",
+                "nunomaduro/larastan": "^2.2.0",
+                "nunomaduro/termwind": "^1.14.0",
+                "pestphp/pest": "^1.22.1"
             },
             "bin": [
                 "builds/pint"
@@ -2929,7 +2774,6 @@
             "description": "An opinionated code formatter for PHP.",
             "homepage": "https://laravel.com",
             "keywords": [
-                "dev",
                 "format",
                 "formatter",
                 "lint",
@@ -2940,7 +2784,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-04-20T15:26:14+00:00"
+            "time": "2022-11-29T16:25:20+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -283,7 +283,6 @@ class Appwrite extends Destination
                 $scope = 'sites.write';
                 $this->sites->create('', '', Framework::OTHER(), BuildRuntime::STATIC1());
             }
-
         } catch (AppwriteException $e) {
             if ($e->getCode() === 403) {
                 throw new \Exception(
@@ -1084,7 +1083,6 @@ class Appwrite extends Destination
                         fn () => $dbForDatabases->createDocuments($collectionId, $this->rowBuffer)
                     ),
                 };
-
             } finally {
                 $this->rowBuffer = [];
             }
@@ -1141,6 +1139,7 @@ class Appwrite extends Destination
                     'none' => Compression::NONE(),
                     'gzip' => Compression::GZIP(),
                     'zstd' => Compression::ZSTD(),
+                    // no break
                     default => throw new \Exception('Invalid Compression: ' . $resource->getCompression(), Exception::CODE_VALIDATION),
                 };
 
@@ -1464,6 +1463,7 @@ class Appwrite extends Destination
                     'bun-1.0' => Runtime::BUN10(),
                     'bun-1.1' => Runtime::BUN11(),
                     'go-1.23' => Runtime::GO123(),
+                    // no break
                     default => throw new \Exception('Invalid Runtime: ' . $resource->getRuntime(), Exception::CODE_VALIDATION),
                 };
 
@@ -1683,6 +1683,7 @@ class Appwrite extends Destination
                     'flutter-3.29' => BuildRuntime::FLUTTER329(),
                     'flutter-3.32' => BuildRuntime::FLUTTER332(),
                     'flutter-3.35' => BuildRuntime::FLUTTER335(),
+                    // no break
                     default => throw new \Exception('Invalid Build Runtime: ' . $resource->getBuildRuntime(), Exception::CODE_VALIDATION),
                 };
 

--- a/src/Migration/Destinations/JSON.php
+++ b/src/Migration/Destinations/JSON.php
@@ -316,5 +316,4 @@ class JSON extends Destination
             return $this->convertValueToJSON($item);
         }, $value);
     }
-
 }

--- a/src/Migration/Resources/Sites/EnvVar.php
+++ b/src/Migration/Resources/Sites/EnvVar.php
@@ -67,5 +67,4 @@ class EnvVar extends Resource
     {
         return $this->value;
     }
-
 }

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -144,7 +144,6 @@ class Appwrite extends Source
             default:
                 throw new \Exception('Unknown source', Exception::CODE_VALIDATION);
         }
-
     }
 
     public static function getName(): string
@@ -354,7 +353,6 @@ class Appwrite extends Source
      */
     private function reportStorage(array $resources, array &$report, array $resourceIds = []): void
     {
-
         if (\in_array(Resource::TYPE_BUCKET, $resources)) {
             $bucketQueries = $this->buildQueries(
                 resourceType: Resource::TYPE_BUCKET,
@@ -869,7 +867,6 @@ class Appwrite extends Source
                         'enabled' => $database['enabled'] ?? true,
                     ]);
                     $databases[] = $newDatabase;
-
                 }
             }
 
@@ -997,7 +994,7 @@ class Appwrite extends Source
                     }
 
                     /** @var Table $table */
-                    $col = match($table->getDatabase()->getType()) {
+                    $col = match ($table->getDatabase()->getType()) {
                         Resource::TYPE_DATABASE_VECTORSDB => self::getColumn($table, $column)->getAttribute(),
                         default => self::getColumn($table, $column),
                     };
@@ -2499,7 +2496,6 @@ class Appwrite extends Source
 
             default => throw new \InvalidArgumentException("Unsupported column type: {$column['type']}"),
         };
-
     }
 
     /**

--- a/src/Migration/Sources/Appwrite/Reader.php
+++ b/src/Migration/Sources/Appwrite/Reader.php
@@ -108,5 +108,4 @@ interface Reader
      */
     public function queryLimit(int $limit): mixed;
     public function getSupportForAttributes(): bool;
-
 }

--- a/src/Migration/Sources/Firebase.php
+++ b/src/Migration/Sources/Firebase.php
@@ -667,7 +667,6 @@ class Firebase extends Source
                 previous: $e
             ));
         }
-
     }
 
     private function exportBuckets(int $batchsize): void


### PR DESCRIPTION
## Summary

Updates the `utopia-php/storage` dependency constraint from `0.0.*` to `2.*` to maintain compatibility with the broader dependency tree.

### Changes
- Updated `composer.json`: `utopia-php/storage` `0.0.*` → `2.*`
- Updated `composer.lock` to reflect the resolved dependency tree