### PR TITLE
Remove deprecated curl_close calls

### DIFF
--- a/src/Migration/Target.php
+++ b/src/Migration/Target.php
@@ -150,7 +150,6 @@ abstract class Target
             throw new \Exception(\curl_error($ch), Exception::CODE_INTERNAL);
         }
 
-        \curl_close($ch);
 
         if ($responseStatus >= 400) {
             if (\is_array($responseBody)) {

--- a/tests/Migration/E2E/Sources/Base.php
+++ b/tests/Migration/E2E/Sources/Base.php
@@ -124,7 +124,6 @@ abstract class Base extends TestCase
             throw new \Exception(curl_error($ch));
         }
 
-        curl_close($ch);
 
         if ($responseStatus >= 400) {
             if (is_array($responseBody)) {


### PR DESCRIPTION
## What does this PR do?

Removes calls to `curl_close()`. Since PHP 8.0, cURL handles are `CurlHandle` objects and `curl_close()` no longer has an effect; handles are released by object lifetime instead. Removing these calls avoids noisy PHP 8.5 deprecation warnings without changing behavior for supported PHP versions.

## Test Plan

- Ran `php -l` on changed PHP files where applicable.
- Confirmed no `curl_close(...)` calls remain in this repository.

## Related PRs and Issues

N/A

### Have you read the Contributing Guidelines on issues?

Yes.
