### PR TITLE
Stop user-data errors leaking to Sentry from migrations

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -344,6 +344,13 @@ class Appwrite extends Destination
                     previous: $e
                 ));
 
+                // User-facing failures (Migration\Exception) are recorded for the migration
+                // report and the loop continues. Anything else is a library bug or infra
+                // failure — rethrow so the worker boundary can route it to Sentry.
+                if (!$e instanceof Exception) {
+                    throw $e;
+                }
+
                 $responseResource = $resource;
             } finally {
                 $this->dbForProject->setPreserveDates(false);
@@ -1074,19 +1081,39 @@ class Appwrite extends Destination
                 }
                 $collectionId = 'database_' . $databaseInternalId . '_collection_' . $tableInternalId;
 
-                match ($this->onDuplicate) {
-                    OnDuplicate::Upsert => $dbForDatabases->skipRelationshipsExistCheck(
-                        fn () => $dbForDatabases->upsertDocuments($collectionId, $this->rowBuffer)
-                    ),
-                    OnDuplicate::Skip => $dbForDatabases->skipDuplicates(
-                        fn () => $dbForDatabases->skipRelationshipsExistCheck(
+                try {
+                    match ($this->onDuplicate) {
+                        OnDuplicate::Upsert => $dbForDatabases->skipRelationshipsExistCheck(
+                            fn () => $dbForDatabases->upsertDocuments($collectionId, $this->rowBuffer)
+                        ),
+                        OnDuplicate::Skip => $dbForDatabases->skipDuplicates(
+                            fn () => $dbForDatabases->skipRelationshipsExistCheck(
+                                fn () => $dbForDatabases->createDocuments($collectionId, $this->rowBuffer)
+                            )
+                        ),
+                        OnDuplicate::Fail => $dbForDatabases->skipRelationshipsExistCheck(
                             fn () => $dbForDatabases->createDocuments($collectionId, $this->rowBuffer)
-                        )
-                    ),
-                    OnDuplicate::Fail => $dbForDatabases->skipRelationshipsExistCheck(
-                        fn () => $dbForDatabases->createDocuments($collectionId, $this->rowBuffer)
-                    ),
-                };
+                        ),
+                    };
+                } catch (DuplicateException $e) {
+                    // Convert to Migration\Exception so the per-resource wrap recognises it
+                    // as a user-facing failure and records it without escalating to Sentry.
+                    throw new Exception(
+                        resourceName: $resource->getName(),
+                        resourceGroup: $resource->getGroup(),
+                        resourceId: $resource->getId(),
+                        message: 'Document already exists',
+                        previous: $e,
+                    );
+                } catch (StructureException $e) {
+                    throw new Exception(
+                        resourceName: $resource->getName(),
+                        resourceGroup: $resource->getGroup(),
+                        resourceId: $resource->getId(),
+                        message: $e->getMessage(),
+                        previous: $e,
+                    );
+                }
             } finally {
                 $this->rowBuffer = [];
             }

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -691,23 +691,14 @@ class Appwrite extends Destination
             $this->dbForProject->checkAttribute($table, $column);
 
             $column = $this->dbForProject->createDocument('attributes', $column);
-        } catch (DuplicateException $e) {
-            $resource->setStatus(Resource::STATUS_ERROR, 'Attribute already exists');
+        } catch (DuplicateException | LimitException $e) {
+            $message = $e instanceof DuplicateException ? 'Attribute already exists' : 'Attribute limit exceeded';
+            $resource->setStatus(Resource::STATUS_ERROR, $message);
             $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
-                message: 'Attribute already exists',
-                previous: $e,
-            ));
-            return false;
-        } catch (LimitException $e) {
-            $resource->setStatus(Resource::STATUS_ERROR, 'Attribute limit exceeded');
-            $this->addError(new Exception(
-                resourceName: $resource->getName(),
-                resourceGroup: $resource->getGroup(),
-                resourceId: $resource->getId(),
-                message: 'Attribute limit exceeded',
+                message: $message,
                 previous: $e,
             ));
             return false;
@@ -753,27 +744,16 @@ class Appwrite extends Destination
                 ]);
 
                 $this->dbForProject->createDocument('attributes', $twoWayAttribute);
-            } catch (DuplicateException $e) {
+            } catch (DuplicateException | LimitException $e) {
                 $this->dbForProject->deleteDocument('attributes', $column->getId());
 
-                $resource->setStatus(Resource::STATUS_ERROR, 'Attribute already exists');
+                $message = $e instanceof DuplicateException ? 'Attribute already exists' : 'Column limit exceeded';
+                $resource->setStatus(Resource::STATUS_ERROR, $message);
                 $this->addError(new Exception(
                     resourceName: $resource->getName(),
                     resourceGroup: $resource->getGroup(),
                     resourceId: $resource->getId(),
-                    message: 'Attribute already exists',
-                    previous: $e,
-                ));
-                return false;
-            } catch (LimitException $e) {
-                $this->dbForProject->deleteDocument('attributes', $column->getId());
-
-                $resource->setStatus(Resource::STATUS_ERROR, 'Column limit exceeded');
-                $this->addError(new Exception(
-                    resourceName: $resource->getName(),
-                    resourceGroup: $resource->getGroup(),
-                    resourceId: $resource->getId(),
-                    message: 'Column limit exceeded',
+                    message: $message,
                     previous: $e,
                 ));
                 return false;

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -333,6 +333,10 @@ class Appwrite extends Destination
                     default => throw new \Exception('Invalid resource group', Exception::CODE_VALIDATION),
                 };
             } catch (\Throwable $e) {
+                // Safety net: expected user-data failures are recorded inline by the
+                // create*() methods via setStatus + addError + return false. Anything
+                // reaching here is a library bug or infra failure — record it for the
+                // user, then rethrow so the worker boundary can route it to Sentry.
                 $resource->setStatus(Resource::STATUS_ERROR, $e->getMessage());
 
                 $this->addError(new Exception(
@@ -344,14 +348,7 @@ class Appwrite extends Destination
                     previous: $e
                 ));
 
-                // User-facing failures (Migration\Exception) are recorded for the migration
-                // report and the loop continues. Anything else is a library bug or infra
-                // failure — rethrow so the worker boundary can route it to Sentry.
-                if (!$e instanceof Exception) {
-                    throw $e;
-                }
-
-                $responseResource = $resource;
+                throw $e;
             } finally {
                 $this->dbForProject->setPreserveDates(false);
             }
@@ -421,12 +418,14 @@ class Appwrite extends Destination
         $validator = new UID();
 
         if (!$validator->isValid($resource->getId())) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, $validator->getDescription());
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: $validator->getDescription(),
-            );
+            ));
+            return false;
         }
 
         $createdAt = $this->normalizeDateTime($resource->getCreatedAt());
@@ -481,12 +480,14 @@ class Appwrite extends Destination
         $validator = new UID();
 
         if (!$validator->isValid($resource->getId())) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, $validator->getDescription());
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: $validator->getDescription(),
-            );
+            ));
+            return false;
         }
 
         $database = $this->dbForProject->getDocument(
@@ -495,12 +496,14 @@ class Appwrite extends Destination
         );
 
         if ($database->isEmpty()) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, 'Database not found');
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Database not found',
-            );
+            ));
+            return false;
         }
 
         $createdAt = $this->normalizeDateTime($resource->getCreatedAt());
@@ -582,12 +585,14 @@ class Appwrite extends Destination
         );
 
         if ($database->isEmpty()) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, 'Database not found');
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Database not found',
-            );
+            ));
+            return false;
         }
 
         $table = $this->dbForProject->getDocument(
@@ -596,41 +601,49 @@ class Appwrite extends Destination
         );
 
         if ($table->isEmpty()) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, 'Table not found');
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Table not found',
-            );
+            ));
+            return false;
         }
 
         if (!empty($resource->getFormat())) {
             if (!Structure::hasFormat($resource->getFormat(), $type)) {
-                throw new Exception(
+                $resource->setStatus(Resource::STATUS_ERROR, "Format {$resource->getFormat()} not available for column type {$type}");
+                $this->addError(new Exception(
                     resourceName: $resource->getName(),
                     resourceGroup: $resource->getGroup(),
                     resourceId: $resource->getId(),
                     message: "Format {$resource->getFormat()} not available for column type {$type}",
-                );
+                ));
+                return false;
             }
         }
 
         if ($resource->isRequired() && $resource->getDefault() !== null) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, 'Cannot set default value for required column');
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Cannot set default value for required column',
-            );
+            ));
+            return false;
         }
 
         if ($resource->isArray() && $resource->getDefault() !== null) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, 'Cannot set default value for array column');
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Cannot set default value for array column',
-            );
+            ));
+            return false;
         }
 
         if ($type === UtopiaDatabase::VAR_RELATIONSHIP) {
@@ -640,12 +653,14 @@ class Appwrite extends Destination
                 $resource->getOptions()['relatedCollection']
             );
             if ($relatedTable->isEmpty()) {
-                throw new Exception(
+                $resource->setStatus(Resource::STATUS_ERROR, 'Related table not found');
+                $this->addError(new Exception(
                     resourceName: $resource->getName(),
                     resourceGroup: $resource->getGroup(),
                     resourceId: $resource->getId(),
                     message: 'Related table not found',
-                );
+                ));
+                return false;
             }
         }
 
@@ -678,20 +693,26 @@ class Appwrite extends Destination
             $this->dbForProject->checkAttribute($table, $column);
 
             $column = $this->dbForProject->createDocument('attributes', $column);
-        } catch (DuplicateException) {
-            throw new Exception(
+        } catch (DuplicateException $e) {
+            $resource->setStatus(Resource::STATUS_ERROR, 'Attribute already exists');
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Attribute already exists',
-            );
-        } catch (LimitException) {
-            throw new Exception(
+                previous: $e,
+            ));
+            return false;
+        } catch (LimitException $e) {
+            $resource->setStatus(Resource::STATUS_ERROR, 'Attribute limit exceeded');
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Attribute limit exceeded',
-            );
+                previous: $e,
+            ));
+            return false;
         } catch (\Throwable $e) {
             $this->dbForProject->purgeCachedDocument('database_' . $database->getSequence(), $table->getId());
             $dbForDatabases->purgeCachedCollection('database_' . $database->getSequence() . '_collection_' . $table->getSequence());
@@ -734,24 +755,30 @@ class Appwrite extends Destination
                 ]);
 
                 $this->dbForProject->createDocument('attributes', $twoWayAttribute);
-            } catch (DuplicateException) {
+            } catch (DuplicateException $e) {
                 $this->dbForProject->deleteDocument('attributes', $column->getId());
 
-                throw new Exception(
+                $resource->setStatus(Resource::STATUS_ERROR, 'Attribute already exists');
+                $this->addError(new Exception(
                     resourceName: $resource->getName(),
                     resourceGroup: $resource->getGroup(),
                     resourceId: $resource->getId(),
                     message: 'Attribute already exists',
-                );
-            } catch (LimitException) {
+                    previous: $e,
+                ));
+                return false;
+            } catch (LimitException $e) {
                 $this->dbForProject->deleteDocument('attributes', $column->getId());
 
-                throw new Exception(
+                $resource->setStatus(Resource::STATUS_ERROR, 'Column limit exceeded');
+                $this->addError(new Exception(
                     resourceName: $resource->getName(),
                     resourceGroup: $resource->getGroup(),
                     resourceId: $resource->getId(),
                     message: 'Column limit exceeded',
-                );
+                    previous: $e,
+                ));
+                return false;
             } catch (\Throwable $e) {
                 $this->dbForProject->purgeCachedDocument('database_' . $database->getSequence(), $relatedTable->getId());
                 $dbForDatabases->purgeCachedCollection('database_' . $database->getSequence() . '_collection_' . $relatedTable->getSequence());
@@ -832,12 +859,14 @@ class Appwrite extends Destination
             $resource->getTable()->getDatabase()->getId(),
         );
         if ($database->isEmpty()) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, 'Database not found');
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Database not found',
-            );
+            ));
+            return false;
         }
 
         $table = $this->dbForProject->getDocument(
@@ -845,12 +874,14 @@ class Appwrite extends Destination
             $resource->getTable()->getId(),
         );
         if ($table->isEmpty()) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, 'Table not found');
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Table not found',
-            );
+            ));
+            return false;
         }
         $dbForDatabases = ($this->getDatabasesDB)($database);
 
@@ -860,12 +891,14 @@ class Appwrite extends Destination
         ], $dbForDatabases->getLimitForIndexes());
 
         if ($count >= $dbForDatabases->getLimitForIndexes()) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, 'Index limit reached for table');
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Index limit reached for table',
-            );
+            ));
+            return false;
         }
 
         // Lengths hidden by default
@@ -922,12 +955,14 @@ class Appwrite extends Destination
 
 
         if (!$validator->isValid($index)) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, 'Invalid index: ' . $validator->getDescription());
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: 'Invalid index: ' . $validator->getDescription(),
-            );
+            ));
+            return false;
         }
 
         $index = $this->dbForProject->createDocument('indexes', $index);
@@ -984,12 +1019,14 @@ class Appwrite extends Destination
         $validator = new UID();
 
         if (!$validator->isValid($resource->getId())) {
-            throw new Exception(
+            $resource->setStatus(Resource::STATUS_ERROR, $validator->getDescription());
+            $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
                 message: $validator->getDescription(),
-            );
+            ));
+            return false;
         }
 
         // Check if document has already been created
@@ -1096,23 +1133,25 @@ class Appwrite extends Destination
                         ),
                     };
                 } catch (DuplicateException $e) {
-                    // Convert to Migration\Exception so the per-resource wrap recognises it
-                    // as a user-facing failure and records it without escalating to Sentry.
-                    throw new Exception(
+                    $resource->setStatus(Resource::STATUS_ERROR, 'Document already exists');
+                    $this->addError(new Exception(
                         resourceName: $resource->getName(),
                         resourceGroup: $resource->getGroup(),
                         resourceId: $resource->getId(),
                         message: 'Document already exists',
                         previous: $e,
-                    );
+                    ));
+                    return false;
                 } catch (StructureException $e) {
-                    throw new Exception(
+                    $resource->setStatus(Resource::STATUS_ERROR, $e->getMessage());
+                    $this->addError(new Exception(
                         resourceName: $resource->getName(),
                         resourceGroup: $resource->getGroup(),
                         resourceId: $resource->getId(),
                         message: $e->getMessage(),
                         previous: $e,
-                    );
+                    ));
+                    return false;
                 }
             } finally {
                 $this->rowBuffer = [];

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -821,19 +821,14 @@ class Appwrite extends Destination
                         throw new \Exception('Failed to create Column', Exception::CODE_INTERNAL);
                     }
             }
-        } catch (\Throwable) {
+        } catch (\Throwable $e) {
             $this->dbForProject->deleteDocument('attributes', $column->getId());
 
             if (isset($twoWayAttribute)) {
                 $this->dbForProject->deleteDocument('attributes', $twoWayAttribute->getId());
             }
 
-            throw new Exception(
-                resourceName: $resource->getName(),
-                resourceGroup: $resource->getGroup(),
-                resourceId: $resource->getId(),
-                message: 'Failed to create column',
-            );
+            throw $e;
         }
 
         if ($type === UtopiaDatabase::VAR_RELATIONSHIP && $options['twoWay']) {
@@ -986,12 +981,7 @@ class Appwrite extends Destination
         } catch (\Throwable $th) {
             $this->dbForProject->deleteDocument('indexes', $index->getId());
 
-            throw new Exception(
-                resourceName: $resource->getName(),
-                resourceGroup: $resource->getGroup(),
-                resourceId: $resource->getId(),
-                message: 'Failed to create index',
-            );
+            throw $th;
         }
 
         $this->dbForProject->purgeCachedDocument(

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -333,10 +333,8 @@ class Appwrite extends Destination
                     default => throw new \Exception('Invalid resource group', Exception::CODE_VALIDATION),
                 };
             } catch (\Throwable $e) {
-                // Safety net: expected user-data failures are recorded inline by the
-                // create*() methods via setStatus + addError + return false. Anything
-                // reaching here is a library bug or infra failure — record it for the
-                // user, then rethrow so the worker boundary can route it to Sentry.
+                // Safety net for unexpected failures — record on the migration and
+                // rethrow so the worker boundary can route bugs to Sentry.
                 $resource->setStatus(Resource::STATUS_ERROR, $e->getMessage());
 
                 $this->addError(new Exception(
@@ -1132,17 +1130,7 @@ class Appwrite extends Destination
                             fn () => $dbForDatabases->createDocuments($collectionId, $this->rowBuffer)
                         ),
                     };
-                } catch (DuplicateException $e) {
-                    $resource->setStatus(Resource::STATUS_ERROR, 'Document already exists');
-                    $this->addError(new Exception(
-                        resourceName: $resource->getName(),
-                        resourceGroup: $resource->getGroup(),
-                        resourceId: $resource->getId(),
-                        message: 'Document already exists',
-                        previous: $e,
-                    ));
-                    return false;
-                } catch (StructureException $e) {
+                } catch (DuplicateException | StructureException $e) {
                     $resource->setStatus(Resource::STATUS_ERROR, $e->getMessage());
                     $this->addError(new Exception(
                         resourceName: $resource->getName(),

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -966,12 +966,12 @@ class Appwrite extends Destination
             } catch (LimitException $e) {
                 $this->dbForProject->deleteDocument(self::META_ATTRIBUTES, $column->getId());
 
-                $resource->setStatus(Resource::STATUS_ERROR, 'Column limit exceeded');
+                $resource->setStatus(Resource::STATUS_ERROR, 'Attribute limit exceeded');
                 $this->addError(new Exception(
                     resourceName: $resource->getName(),
                     resourceGroup: $resource->getGroup(),
                     resourceId: $resource->getId(),
-                    message: 'Column limit exceeded',
+                    message: 'Attribute limit exceeded',
                     previous: $e,
                 ));
                 return false;

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -400,8 +400,6 @@ class Appwrite extends Destination
                     default => throw new \Exception('Invalid resource group', Exception::CODE_VALIDATION),
                 };
             } catch (\Throwable $e) {
-                // Safety net for unexpected failures — record on the migration and
-                // rethrow so the worker boundary can route bugs to Sentry.
                 $resource->setStatus(Resource::STATUS_ERROR, $e->getMessage());
 
                 $this->addError(new Exception(
@@ -413,7 +411,7 @@ class Appwrite extends Destination
                     previous: $e
                 ));
 
-                throw $e;
+                $responseResource = $resource;
             } finally {
                 $this->dbForProject->setPreserveDates(false);
             }

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -691,14 +691,23 @@ class Appwrite extends Destination
             $this->dbForProject->checkAttribute($table, $column);
 
             $column = $this->dbForProject->createDocument('attributes', $column);
-        } catch (DuplicateException | LimitException $e) {
-            $message = $e instanceof DuplicateException ? 'Attribute already exists' : 'Attribute limit exceeded';
-            $resource->setStatus(Resource::STATUS_ERROR, $message);
+        } catch (DuplicateException $e) {
+            $resource->setStatus(Resource::STATUS_ERROR, 'Attribute already exists');
             $this->addError(new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
                 resourceId: $resource->getId(),
-                message: $message,
+                message: 'Attribute already exists',
+                previous: $e,
+            ));
+            return false;
+        } catch (LimitException $e) {
+            $resource->setStatus(Resource::STATUS_ERROR, 'Attribute limit exceeded');
+            $this->addError(new Exception(
+                resourceName: $resource->getName(),
+                resourceGroup: $resource->getGroup(),
+                resourceId: $resource->getId(),
+                message: 'Attribute limit exceeded',
                 previous: $e,
             ));
             return false;
@@ -744,16 +753,27 @@ class Appwrite extends Destination
                 ]);
 
                 $this->dbForProject->createDocument('attributes', $twoWayAttribute);
-            } catch (DuplicateException | LimitException $e) {
+            } catch (DuplicateException $e) {
                 $this->dbForProject->deleteDocument('attributes', $column->getId());
 
-                $message = $e instanceof DuplicateException ? 'Attribute already exists' : 'Column limit exceeded';
-                $resource->setStatus(Resource::STATUS_ERROR, $message);
+                $resource->setStatus(Resource::STATUS_ERROR, 'Attribute already exists');
                 $this->addError(new Exception(
                     resourceName: $resource->getName(),
                     resourceGroup: $resource->getGroup(),
                     resourceId: $resource->getId(),
-                    message: $message,
+                    message: 'Attribute already exists',
+                    previous: $e,
+                ));
+                return false;
+            } catch (LimitException $e) {
+                $this->dbForProject->deleteDocument('attributes', $column->getId());
+
+                $resource->setStatus(Resource::STATUS_ERROR, 'Column limit exceeded');
+                $this->addError(new Exception(
+                    resourceName: $resource->getName(),
+                    resourceGroup: $resource->getGroup(),
+                    resourceId: $resource->getId(),
+                    message: 'Column limit exceeded',
                     previous: $e,
                 ));
                 return false;
@@ -1110,7 +1130,17 @@ class Appwrite extends Destination
                             fn () => $dbForDatabases->createDocuments($collectionId, $this->rowBuffer)
                         ),
                     };
-                } catch (DuplicateException | StructureException $e) {
+                } catch (DuplicateException $e) {
+                    $resource->setStatus(Resource::STATUS_ERROR, 'Document already exists');
+                    $this->addError(new Exception(
+                        resourceName: $resource->getName(),
+                        resourceGroup: $resource->getGroup(),
+                        resourceId: $resource->getId(),
+                        message: 'Document already exists',
+                        previous: $e,
+                    ));
+                    return false;
+                } catch (StructureException $e) {
                     $resource->setStatus(Resource::STATUS_ERROR, $e->getMessage());
                     $this->addError(new Exception(
                         resourceName: $resource->getName(),


### PR DESCRIPTION
## Summary

Per-resource user errors thrown by `Destinations/Appwrite.php` were leaking to Sentry through the migrations worker. This PR fixes the routing at the library layer.

- Convert ~15 `throw new Exception(...)` user-error sites in `create*()` methods to `setStatus + addError + return false`. No exception bubbles for expected outcomes; the failure is recorded where detected.
- Per-resource wrap at `import()` becomes a pure safety net: record + rethrow. Library bugs and infra failures bubble through; user errors stay in the migration report.
- Row-flush block catches `DuplicateException` and `StructureException` from the database adapter and re-throws as `Migration\Exception` so the wrap classifies them as user-facing.
- Critical context: `Migration\Exception` is now the library's marker for "user-facing migration error". The Appwrite worker uses `instanceof Migration\Exception` to decide Sentry routing.

## Motivation

Errors like *"Document already exists"*, *"Attribute already exists"*, *"Cannot set default value for array column"*, *"Invalid document structure: Missing required attribute X"* were being thrown with code 0 or PDO codes (e.g. 23000), and the migration worker's `code === 0 || >= 500` heuristic re-published every one of them to Sentry. ~80% of the noise on the `appwrite-queue-migrations` Sentry stream came from this path.

After this PR, expected user-data conditions never throw; only bugs/infra do.

## Test plan

- [ ] Migration with a duplicate column → *"Attribute already exists"* appears in the migration report, no Sentry event
- [ ] Migration with a duplicate row → *"Document already exists"* in the report only
- [ ] Migration with malformed source data → *"Invalid document structure"* in the report only
- [ ] Library bug (synthetic TypeError) → recorded in report **and** reaches Sentry with full trace