### PR TITLE
fix(destination): stop propagating source DSN to destination database documents

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -104,6 +104,17 @@ class Appwrite extends Destination
     protected $getDatabasesDB;
 
     /**
+     * Resolves the DSN written into the destination's `_databases.database` for
+     * a migrated database. When unset, the attribute is left blank and the
+     * runtime falls back to the destination project's DSN — correct for legacy
+     * single-DSN projects, but cross-instance / multi-type setups must inject
+     * a resolver so source DSNs don't bleed into the destination metadata.
+     *
+     * @var (callable(Database $resource): string)|null
+     */
+    protected $getDatabaseDSN;
+
+    /**
      * @var array<UtopiaDocument>
      */
     private array $rowBuffer = [];
@@ -139,6 +150,7 @@ class Appwrite extends Destination
      * @param callable(UtopiaDocument $database):UtopiaDatabase $getDatabasesDB
      * @param array<array<string, mixed>> $collectionStructure
      * @param OnDuplicate $onDuplicate Behavior when a row with an existing $id is encountered.
+     * @param (callable(Database $resource): string)|null $getDatabaseDSN Resolver for the destination's `_databases.database` value. Required for cross-instance migrations to prevent the source DSN from being written into the destination project's metadata.
      */
     public function __construct(
         string $project,
@@ -148,6 +160,7 @@ class Appwrite extends Destination
         callable $getDatabasesDB,
         protected array $collectionStructure,
         protected OnDuplicate $onDuplicate = OnDuplicate::Fail,
+        ?callable $getDatabaseDSN = null,
     ) {
         $this->project = $project;
         $this->endpoint = $endpoint;
@@ -166,6 +179,21 @@ class Appwrite extends Destination
         $this->users = new Users($this->client);
 
         $this->getDatabasesDB = $getDatabasesDB;
+        $this->getDatabaseDSN = $getDatabaseDSN;
+    }
+
+    /**
+     * Resolve the DSN written into the destination's `_databases.database`.
+     * Without a resolver, leave it blank — the source DSN must never be
+     * propagated, since cross-instance source/destination DSNs differ and
+     * propagation routes destination reads to the wrong host (see PR #151).
+     */
+    private function resolveDestinationDsn(Database $resource): string
+    {
+        if ($this->getDatabaseDSN === null) {
+            return '';
+        }
+        return ($this->getDatabaseDSN)($resource);
     }
 
     /** Orphan cleanup runs only after a successful migration — a mid-run throw preserves the destination as-is. */
@@ -519,7 +547,7 @@ class Appwrite extends Destination
                         'enabled' => $resource->getEnabled(),
                         'type' => empty($resource->getType()) ? 'legacy' : $resource->getType(),
                         'originalId' => empty($resource->getOriginalId()) ? null : $resource->getOriginalId(),
-                        'database' => $resource->getDatabase(),
+                        'database' => $this->resolveDestinationDsn($resource),
                         '$updatedAt' => $updatedAt,
                     ]));
                     $resource->setSequence($existing->getSequence());
@@ -541,8 +569,8 @@ class Appwrite extends Destination
             '$updatedAt' => $updatedAt,
             'originalId' => empty($resource->getOriginalId()) ? null : $resource->getOriginalId(),
             'type' => empty($resource->getType()) ? 'legacy' : $resource->getType(),
-            // source and destination can be in different location
-            'database' => $resource->getDatabase()
+            // Source and destination can be in different locations; never write the source DSN here.
+            'database' => $this->resolveDestinationDsn($resource),
         ]));
 
         $resource->setSequence($database->getSequence());

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -1610,7 +1610,7 @@ class Appwrite extends Destination
             && $existing->getAttribute('enabled')    === $resource->getEnabled()
             && $existing->getAttribute('type')       === $sourceType
             && $existing->getAttribute('originalId') === $sourceOriginalId
-            && $existing->getAttribute('database')   === $resource->getDatabase();
+            && $existing->getAttribute('database')   === $this->resolveDestinationDsn($resource);
     }
 
     private function tableSpecMatches(UtopiaDocument $existing, Table $resource): bool

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -104,11 +104,13 @@ class Appwrite extends Destination
     protected $getDatabasesDB;
 
     /**
-     * Resolves the DSN written into the destination's `_databases.database` for
-     * a migrated database. When unset, the attribute is left blank and the
-     * runtime falls back to the destination project's DSN — correct for legacy
-     * single-DSN projects, but cross-instance / multi-type setups must inject
-     * a resolver so source DSNs don't bleed into the destination metadata.
+     * Resolves the DSN written into the destination's `_databases.database`
+     * for a migrated database. When the source and destination projects don't
+     * share the same DSN — e.g. one project is on a host the other isn't —
+     * pass a resolver so the destination metadata carries its own DSN instead
+     * of the source's. When unset, the attribute is left blank and the
+     * runtime falls back to the destination project's DSN at read time, which
+     * is safe for single-host single-type setups.
      *
      * @var (callable(Database $resource): string)|null
      */
@@ -150,7 +152,7 @@ class Appwrite extends Destination
      * @param callable(UtopiaDocument $database):UtopiaDatabase $getDatabasesDB
      * @param array<array<string, mixed>> $collectionStructure
      * @param OnDuplicate $onDuplicate Behavior when a row with an existing $id is encountered.
-     * @param (callable(Database $resource): string)|null $getDatabaseDSN Resolver for the destination's `_databases.database` value. Required for cross-instance migrations to prevent the source DSN from being written into the destination project's metadata.
+     * @param (callable(Database $resource): string)|null $getDatabaseDSN Resolver for the destination's `_databases.database` value. Pass when the destination project's DSN differs from the source's, so the destination row carries its own DSN instead of inheriting the source's.
      */
     public function __construct(
         string $project,
@@ -185,8 +187,9 @@ class Appwrite extends Destination
     /**
      * Resolve the DSN written into the destination's `_databases.database`.
      * Without a resolver, leave it blank — the source DSN must never be
-     * propagated, since cross-instance source/destination DSNs differ and
-     * propagation routes destination reads to the wrong host (see PR #151).
+     * propagated as the default, since when source and destination DSNs
+     * differ propagation routes destination reads to the wrong host (the
+     * regression PR #151 introduced).
      */
     private function resolveDestinationDsn(Database $resource): string
     {
@@ -569,7 +572,7 @@ class Appwrite extends Destination
             '$updatedAt' => $updatedAt,
             'originalId' => empty($resource->getOriginalId()) ? null : $resource->getOriginalId(),
             'type' => empty($resource->getType()) ? 'legacy' : $resource->getType(),
-            // Source and destination can be in different locations; never write the source DSN here.
+            // Resolved by the destination's resolver (or left blank); never copy the source's DSN by default.
             'database' => $this->resolveDestinationDsn($resource),
         ]));
 

--- a/tests/Migration/Unit/Destinations/AppwriteDestinationDsnTest.php
+++ b/tests/Migration/Unit/Destinations/AppwriteDestinationDsnTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Utopia\Tests\Unit\Destinations;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Utopia\Database\Database as UtopiaDatabase;
+use Utopia\Migration\Destinations\Appwrite as AppwriteDestination;
+use Utopia\Migration\Destinations\OnDuplicate;
+use Utopia\Migration\Resources\Database\Database as DatabaseResource;
+
+/**
+ * Regression for PR #151: the destination must never write the source's DSN
+ * into `_databases.database`. With no resolver, the value must be blank so
+ * the runtime falls back to the destination project's DSN. With a resolver,
+ * the resolver's value must be written and the source's value ignored.
+ *
+ * Reproduces the comuneo-pre-production incident where post-migration
+ * `_databases.database` rows pointed at the source's host (db11) and
+ * destination reads hit `Table 'appwrite._<tenant>__metadata' doesn't exist`.
+ */
+class AppwriteDestinationDsnTest extends TestCase
+{
+    public function testWithoutResolverReturnsEmptyString(): void
+    {
+        $destination = $this->makeDestination(getDatabaseDSN: null);
+        $resource = $this->makeResource(sourceDsn: 'database_db_fra1_self_hosted_11_0');
+
+        $resolved = $this->invokeResolver($destination, $resource);
+
+        $this->assertSame('', $resolved, 'Without a resolver the destination must not propagate the source DSN.');
+    }
+
+    public function testWithResolverUsesItsReturnValue(): void
+    {
+        $expected = 'appwrite://database_db_fra1_self_hosted_17_0?database=appwrite&namespace=_1';
+        $destination = $this->makeDestination(
+            getDatabaseDSN: fn (DatabaseResource $r): string => $expected,
+        );
+        $resource = $this->makeResource(sourceDsn: 'database_db_fra1_self_hosted_11_0');
+
+        $resolved = $this->invokeResolver($destination, $resource);
+
+        $this->assertSame($expected, $resolved);
+        $this->assertNotSame($resource->getDatabase(), $resolved, 'Source DSN must not leak through the resolver path.');
+    }
+
+    public function testResolverReceivesTheResource(): void
+    {
+        $captured = null;
+        $destination = $this->makeDestination(
+            getDatabaseDSN: function (DatabaseResource $r) use (&$captured): string {
+                $captured = $r;
+                return 'resolved';
+            },
+        );
+        $resource = $this->makeResource(sourceDsn: 'src');
+
+        $this->invokeResolver($destination, $resource);
+
+        $this->assertSame($resource, $captured);
+    }
+
+    private function makeDestination(?callable $getDatabaseDSN): AppwriteDestination
+    {
+        return new AppwriteDestination(
+            project: 'destination-project',
+            endpoint: 'http://example.test/v1',
+            key: 'test-key',
+            dbForProject: $this->createStub(UtopiaDatabase::class),
+            getDatabasesDB: fn (): UtopiaDatabase => $this->createStub(UtopiaDatabase::class),
+            collectionStructure: ['attributes' => [], 'indexes' => []],
+            onDuplicate: OnDuplicate::Fail,
+            getDatabaseDSN: $getDatabaseDSN,
+        );
+    }
+
+    private function makeResource(string $sourceDsn): DatabaseResource
+    {
+        return new DatabaseResource(
+            id: 'src-database',
+            name: 'src',
+            type: 'legacy',
+            database: $sourceDsn,
+        );
+    }
+
+    private function invokeResolver(AppwriteDestination $destination, DatabaseResource $resource): string
+    {
+        $method = (new ReflectionClass(AppwriteDestination::class))->getMethod('resolveDestinationDsn');
+        /** @var string $value */
+        $value = $method->invoke($destination, $resource);
+        return $value;
+    }
+}

--- a/tests/Migration/Unit/Destinations/AppwriteDestinationDsnTest.php
+++ b/tests/Migration/Unit/Destinations/AppwriteDestinationDsnTest.php
@@ -5,6 +5,7 @@ namespace Utopia\Tests\Unit\Destinations;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Utopia\Database\Database as UtopiaDatabase;
+use Utopia\Database\Document as UtopiaDocument;
 use Utopia\Migration\Destinations\Appwrite as AppwriteDestination;
 use Utopia\Migration\Destinations\OnDuplicate;
 use Utopia\Migration\Resources\Database\Database as DatabaseResource;
@@ -68,7 +69,7 @@ class AppwriteDestinationDsnTest extends TestCase
             endpoint: 'http://example.test/v1',
             key: 'test-key',
             dbForProject: $this->createStub(UtopiaDatabase::class),
-            getDatabasesDB: fn (): UtopiaDatabase => $this->createStub(UtopiaDatabase::class),
+            getDatabasesDB: fn (UtopiaDocument $database): UtopiaDatabase => $this->createStub(UtopiaDatabase::class),
             collectionStructure: ['attributes' => [], 'indexes' => []],
             onDuplicate: OnDuplicate::Fail,
             getDatabaseDSN: $getDatabaseDSN,


### PR DESCRIPTION
## Summary

- Reintroduce an opt-in `getDatabaseDSN` resolver on `Destinations\Appwrite`.
- Without a resolver, leave `_databases.database` blank so the runtime falls back to the destination project's DSN. Never write the source's DSN.
- Apply in both the `Create` and `Overwrite` branches of `createDatabase()`.
- Add a unit regression locking down the new contract.

## Why

PR #151 ("Refactor Appwrite migration to remove unused getDatabaseDSN callable …") removed the destination-DSN resolver on the assumption it was unused, and replaced its call site with `$resource->getDatabase()` — the **source's** DSN. Any Appwrite→Appwrite migration where the source and destination projects don't share the same DSN (cross-host within the same cloud instance, cross-region, mixed shared-tables migration) then wrote the source's host string into the destination project's `_databases` rows.

On Cloud this triggered the comuneo-pre-production incident: destination reads opened a pool to the source host, then derived the namespace from the destination project's sequence (because the source's value isn't in `_APP_DATABASE_SHARED_TABLES`), producing

```
SQLSTATE[42S02]: Base table or view not found: 1146
Table 'appwrite._<tenant>__metadata' doesn't exist
```

for every database the user touched, and silently aborted the per-table schema creates so destination data was unrecoverable from the request path.

## Behavior

| Caller passes a resolver? | `_databases.database` written as |
|---|---|
| Yes (consumer can return whatever DSN is correct for the destination project, by type or otherwise) | resolver's return value |
| No (single-host single-type setups) | `''` — runtime falls back to the destination project's DSN |

The fallback is never the source DSN, so consumers that don't update get safer behavior than today.

## Follow-up

- Cloud needs to thread a resolver into `new DestinationAppwrite(…)` and bump this dependency. (Done in `appwrite-labs/cloud#3979`, which also adds a worker-level regression test.)
- Cloud will ship a one-shot patch task to repair already-corrupted `_*_databases.database` rows from earlier migrations. (Done in `appwrite-labs/cloud#3977`.)

## Test plan

- [x] `composer test` (Unit)
- [x] `composer lint` (Pint)
- [x] `composer check` (PHPStan level 3)
- [x] New regression: `tests/Migration/Unit/Destinations/AppwriteDestinationDsnTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)