### PR TITLE
Add API key migration support

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -50,6 +50,7 @@ use Utopia\Migration\Resources\Database\Table;
 use Utopia\Migration\Resources\Functions\Deployment;
 use Utopia\Migration\Resources\Functions\EnvVar;
 use Utopia\Migration\Resources\Functions\Func;
+use Utopia\Migration\Resources\Integrations\ApiKey;
 use Utopia\Migration\Resources\Integrations\Platform;
 use Utopia\Migration\Resources\Messaging\Message;
 use Utopia\Migration\Resources\Messaging\Provider;
@@ -80,6 +81,11 @@ class Appwrite extends Destination
      * @var callable(UtopiaDocument $database): UtopiaDatabase
     */
     protected $getDatabasesDB;
+
+    private bool $consoleKeyFetched = false;
+
+    private ?string $consoleKey = null;
+
 
     /**
      * @var array<UtopiaDocument>
@@ -120,7 +126,37 @@ class Appwrite extends Destination
         $this->teams = new Teams($this->client);
         $this->users = new Users($this->client);
 
+        $this->headers['x-appwrite-project'] = $this->project;
+        $this->headers['x-appwrite-key'] = $this->key;
+
         $this->getDatabasesDB = $getDatabasesDB;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    protected function getConsoleHeaders(): ?array
+    {
+        if (!$this->consoleKeyFetched) {
+            $this->consoleKeyFetched = true;
+
+            try {
+                $response = $this->call('POST', '/migrations/appwrite/console-key');
+                $this->consoleKey = $response['key'] ?? null;
+            } catch (\Throwable) {
+                $this->consoleKey = null;
+            }
+        }
+
+        if ($this->consoleKey === null) {
+            return null;
+        }
+
+        return [
+            'Content-Type' => 'application/json',
+            'x-appwrite-project' => 'console',
+            'x-appwrite-key' => $this->consoleKey,
+        ];
     }
 
     public static function getName(): string
@@ -175,6 +211,7 @@ class Appwrite extends Destination
 
             // Integrations
             Resource::TYPE_PLATFORM,
+            Resource::TYPE_API_KEY,
         ];
     }
 
@@ -2206,9 +2243,13 @@ class Appwrite extends Destination
                 /** @var Platform $resource */
                 $this->createPlatform($resource);
                 break;
+            case Resource::TYPE_API_KEY:
+                /** @var ApiKey $resource */
+                $this->createApiKey($resource);
+                break;
         }
 
-        if ($resource->getStatus() !== Resource::STATUS_SKIPPED) {
+        if ($resource->getStatus() !== Resource::STATUS_SKIPPED && $resource->getStatus() !== Resource::STATUS_ERROR) {
             $resource->setStatus(Resource::STATUS_SUCCESS);
         }
 
@@ -2254,6 +2295,44 @@ class Appwrite extends Destination
         }
 
         $this->dbForPlatform->purgeCachedDocument('projects', $this->project);
+
+        return true;
+    }
+
+    protected function createApiKey(ApiKey $resource): bool
+    {
+        $consoleHeaders = $this->getConsoleHeaders();
+
+        if ($consoleHeaders === null) {
+            throw new \Exception('Failed to get console headers');
+        }
+
+        try {
+            $params = [
+                'keyId' => ID::unique(),
+                'name' => $resource->getApiKeyName(),
+                'scopes' => $resource->getScopes(),
+            ];
+
+            $expire = $resource->getExpire();
+            if (!empty($expire)) {
+                $params['expire'] = $expire;
+            }
+
+            $this->call(
+                'POST',
+                '/projects/' . $this->project . '/keys',
+                $consoleHeaders,
+                $params
+            );
+        } catch (\Throwable $e) {
+            if ($e->getCode() === 409) {
+                $resource->setStatus(Resource::STATUS_SKIPPED, 'API key already exists');
+                return false;
+            }
+
+            throw $e;
+        }
 
         return true;
     }

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -3151,9 +3151,8 @@ class Appwrite extends Destination
         try {
             $this->dbForPlatform->createDocument('keys', new UtopiaDocument([
                 '$id' => ID::unique(),
-                // SDK's Key model doesn't expose $permissions, so we can't read the source doc's perms.
-                // Mirror appwrite/appwrite's createKey controller default — `dbForPlatform.keys` is
-                // gated by endpoint scope, not document perms, so this is the upstream invariant.
+                // SDK's Key model doesn't expose $permissions, so we can't copy source perms through.
+                // Mirror appwrite/appwrite's createKey controller so migrated docs match natively-created keys.
                 '$permissions' => [
                     Permission::read(Role::any()),
                     Permission::update(Role::any()),

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -91,8 +91,6 @@ class Appwrite extends Destination
     protected Client $client;
     protected string $project;
 
-    protected string $key;
-
     private Functions $functions;
     private Messaging $messaging;
     private Sites $sites;
@@ -169,8 +167,6 @@ class Appwrite extends Destination
         ?callable $getDatabaseDSN = null,
     ) {
         $this->project = $project;
-        $this->endpoint = $endpoint;
-        $this->key = $key;
 
         $this->client = (new Client())
             ->setEndpoint($endpoint)
@@ -183,9 +179,6 @@ class Appwrite extends Destination
         $this->storage = new Storage($this->client);
         $this->teams = new Teams($this->client);
         $this->users = new Users($this->client);
-
-        $this->headers['x-appwrite-project'] = $this->project;
-        $this->headers['x-appwrite-key'] = $this->key;
 
         $this->getDatabasesDB = $getDatabasesDB;
         $this->getDatabaseDSN = $getDatabaseDSN;
@@ -3085,7 +3078,7 @@ class Appwrite extends Destination
                 break;
         }
 
-        if ($resource->getStatus() !== Resource::STATUS_SKIPPED && $resource->getStatus() !== Resource::STATUS_ERROR) {
+        if ($resource->getStatus() !== Resource::STATUS_SKIPPED) {
             $resource->setStatus(Resource::STATUS_SUCCESS);
         }
 

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -3151,11 +3151,7 @@ class Appwrite extends Destination
         try {
             $this->dbForPlatform->createDocument('keys', new UtopiaDocument([
                 '$id' => ID::unique(),
-                '$permissions' => [
-                    Permission::read(Role::any()),
-                    Permission::update(Role::any()),
-                    Permission::delete(Role::any()),
-                ],
+                '$permissions' => $resource->getPermissions(),
                 'projectInternalId' => $this->projectInternalId,
                 'projectId' => $this->project,
                 'resourceInternalId' => $this->projectInternalId,

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -3135,7 +3135,8 @@ class Appwrite extends Destination
     protected function createApiKey(ApiKey $resource): bool
     {
         $existing = $this->dbForPlatform->findOne('keys', [
-            Query::equal('projectInternalId', [$this->projectInternalId]),
+            Query::equal('resourceType', ['projects']),
+            Query::equal('resourceInternalId', [$this->projectInternalId]),
             Query::equal('name', [$resource->getApiKeyName()]),
         ]);
 

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -3151,8 +3151,7 @@ class Appwrite extends Destination
         try {
             $this->dbForPlatform->createDocument('keys', new UtopiaDocument([
                 '$id' => ID::unique(),
-                // SDK's Key model doesn't expose $permissions, so we can't copy source perms through.
-                // Mirror appwrite/appwrite's createKey controller so migrated docs match natively-created keys.
+                // Match upstream createKey — keys carry no per-doc perm semantics in Appwrite.
                 '$permissions' => [
                     Permission::read(Role::any()),
                     Permission::update(Role::any()),

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -3152,7 +3152,7 @@ class Appwrite extends Destination
         try {
             $this->dbForPlatform->createDocument('keys', new UtopiaDocument([
                 '$id' => ID::unique(),
-                '$permissions' => [],
+                '$permissions' => $resource->getPermissions(),
                 'resourceInternalId' => $this->projectInternalId,
                 'resourceId' => $this->project,
                 'resourceType' => 'projects',

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -105,11 +105,6 @@ class Appwrite extends Destination
     */
     protected $getDatabasesDB;
 
-    private bool $consoleKeyFetched = false;
-
-    private ?string $consoleKey = null;
-
-
     /**
      * Resolves the DSN written into the destination's `_databases.database`
      * for a migrated database. When the source and destination projects don't
@@ -230,33 +225,6 @@ class Appwrite extends Destination
         $this->rowBuffer = [];
         $this->orphansByTable = [];
         $this->processedTwoWayPairs = [];
-    }
-
-    /**
-     * @return array<string, string>|null
-     */
-    protected function getConsoleHeaders(): ?array
-    {
-        if (!$this->consoleKeyFetched) {
-            $this->consoleKeyFetched = true;
-
-            try {
-                $response = $this->call('POST', '/migrations/appwrite/console-key');
-                $this->consoleKey = $response['key'] ?? null;
-            } catch (\Throwable) {
-                $this->consoleKey = null;
-            }
-        }
-
-        if ($this->consoleKey === null) {
-            return null;
-        }
-
-        return [
-            'Content-Type' => 'application/json',
-            'x-appwrite-project' => 'console',
-            'x-appwrite-key' => $this->consoleKey,
-        ];
     }
 
     public static function getName(): string
@@ -3169,38 +3137,48 @@ class Appwrite extends Destination
 
     protected function createApiKey(ApiKey $resource): bool
     {
-        $consoleHeaders = $this->getConsoleHeaders();
+        $existing = $this->dbForPlatform->findOne('keys', [
+            Query::equal('projectInternalId', [$this->projectInternalId]),
+            Query::equal('name', [$resource->getApiKeyName()]),
+        ]);
 
-        if ($consoleHeaders === null) {
-            throw new \Exception('Failed to get console headers');
+        if ($existing !== false && !$existing->isEmpty()) {
+            $resource->setStatus(Resource::STATUS_SKIPPED, 'API key already exists');
+            return false;
         }
+
+        $createdAt = $this->normalizeDateTime($resource->getCreatedAt());
+        $updatedAt = $this->normalizeDateTime($resource->getUpdatedAt(), $createdAt);
+        $expire = $resource->getExpire();
 
         try {
-            $params = [
-                'keyId' => ID::unique(),
+            $this->dbForPlatform->createDocument('keys', new UtopiaDocument([
+                '$id' => ID::unique(),
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::update(Role::any()),
+                    Permission::delete(Role::any()),
+                ],
+                'projectInternalId' => $this->projectInternalId,
+                'projectId' => $this->project,
+                'resourceInternalId' => $this->projectInternalId,
+                'resourceId' => $this->project,
+                'resourceType' => 'projects',
                 'name' => $resource->getApiKeyName(),
                 'scopes' => $resource->getScopes(),
-            ];
-
-            $expire = $resource->getExpire();
-            if (!empty($expire)) {
-                $params['expire'] = $expire;
-            }
-
-            $this->call(
-                'POST',
-                '/projects/' . $this->project . '/keys',
-                $consoleHeaders,
-                $params
-            );
-        } catch (\Throwable $e) {
-            if ($e->getCode() === 409) {
-                $resource->setStatus(Resource::STATUS_SKIPPED, 'API key already exists');
-                return false;
-            }
-
-            throw $e;
+                'expire' => empty($expire) ? null : $expire,
+                'sdks' => $resource->getSdks(),
+                'accessedAt' => null,
+                'secret' => 'standard_' . \bin2hex(\random_bytes(128)),
+                '$createdAt' => $createdAt,
+                '$updatedAt' => $updatedAt,
+            ]));
+        } catch (DuplicateException) {
+            $resource->setStatus(Resource::STATUS_SKIPPED, 'API key already exists');
+            return false;
         }
+
+        $this->dbForPlatform->purgeCachedDocument('projects', $this->project);
 
         return true;
     }

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -91,6 +91,8 @@ class Appwrite extends Destination
     protected Client $client;
     protected string $project;
 
+    protected string $key;
+
     private Functions $functions;
     private Messaging $messaging;
     private Sites $sites;
@@ -167,6 +169,8 @@ class Appwrite extends Destination
         ?callable $getDatabaseDSN = null,
     ) {
         $this->project = $project;
+        $this->endpoint = $endpoint;
+        $this->key = $key;
 
         $this->client = (new Client())
             ->setEndpoint($endpoint)

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -3152,14 +3152,7 @@ class Appwrite extends Destination
         try {
             $this->dbForPlatform->createDocument('keys', new UtopiaDocument([
                 '$id' => ID::unique(),
-                // Match upstream createKey — keys carry no per-doc perm semantics in Appwrite.
-                '$permissions' => [
-                    Permission::read(Role::any()),
-                    Permission::update(Role::any()),
-                    Permission::delete(Role::any()),
-                ],
-                'projectInternalId' => $this->projectInternalId,
-                'projectId' => $this->project,
+                '$permissions' => [],
                 'resourceInternalId' => $this->projectInternalId,
                 'resourceId' => $this->project,
                 'resourceType' => 'projects',

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -3151,7 +3151,14 @@ class Appwrite extends Destination
         try {
             $this->dbForPlatform->createDocument('keys', new UtopiaDocument([
                 '$id' => ID::unique(),
-                '$permissions' => $resource->getPermissions(),
+                // SDK's Key model doesn't expose $permissions, so we can't read the source doc's perms.
+                // Mirror appwrite/appwrite's createKey controller default — `dbForPlatform.keys` is
+                // gated by endpoint scope, not document perms, so this is the upstream invariant.
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::update(Role::any()),
+                    Permission::delete(Role::any()),
+                ],
                 'projectInternalId' => $this->projectInternalId,
                 'projectId' => $this->project,
                 'resourceInternalId' => $this->projectInternalId,

--- a/src/Migration/Resource.php
+++ b/src/Migration/Resource.php
@@ -73,6 +73,7 @@ abstract class Resource implements \JsonSerializable
 
     // Integrations
     public const TYPE_PLATFORM = 'platform';
+    public const TYPE_API_KEY = 'api-key';
     public const TYPE_SUBSCRIBER = 'subscriber';
 
     public const TYPE_MESSAGE = 'message';
@@ -109,6 +110,7 @@ abstract class Resource implements \JsonSerializable
         self::TYPE_TEAM,
         self::TYPE_MEMBERSHIP,
         self::TYPE_PLATFORM,
+        self::TYPE_API_KEY,
         self::TYPE_PROVIDER,
         self::TYPE_TOPIC,
         self::TYPE_SUBSCRIBER,

--- a/src/Migration/Resources/Integrations/ApiKey.php
+++ b/src/Migration/Resources/Integrations/ApiKey.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Utopia\Migration\Resources\Integrations;
+
+use Utopia\Migration\Resource;
+use Utopia\Migration\Transfer;
+
+class ApiKey extends Resource
+{
+    /**
+     * @param string $id
+     * @param string $name
+     * @param array<string> $scopes
+     * @param string $expire
+     * @param string $accessedAt
+     * @param array<string> $sdks
+     * @param string $createdAt
+     * @param string $updatedAt
+     */
+    public function __construct(
+        string $id,
+        private readonly string $name,
+        private readonly array $scopes = [],
+        private readonly string $expire = '',
+        private readonly string $accessedAt = '',
+        private readonly array $sdks = [],
+        string $createdAt = '',
+        string $updatedAt = '',
+    ) {
+        $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
+    }
+
+    /**
+     * @param array<string, mixed> $array
+     * @return self
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self(
+            $array['id'],
+            $array['name'],
+            $array['scopes'] ?? [],
+            $array['expire'] ?? '',
+            $array['accessedAt'] ?? '',
+            $array['sdks'] ?? [],
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'scopes' => $this->scopes,
+            'expire' => $this->expire,
+            'accessedAt' => $this->accessedAt,
+            'sdks' => $this->sdks,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
+        ];
+    }
+
+    public static function getName(): string
+    {
+        return Resource::TYPE_API_KEY;
+    }
+
+    public function getGroup(): string
+    {
+        return Transfer::GROUP_INTEGRATIONS;
+    }
+
+    public function getApiKeyName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getScopes(): array
+    {
+        return $this->scopes;
+    }
+
+    public function getExpire(): string
+    {
+        return $this->expire;
+    }
+
+    public function getAccessedAt(): string
+    {
+        return $this->accessedAt;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getSdks(): array
+    {
+        return $this->sdks;
+    }
+}

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -53,6 +53,7 @@ use Utopia\Migration\Resources\Database\VectorsDB;
 use Utopia\Migration\Resources\Functions\Deployment;
 use Utopia\Migration\Resources\Functions\EnvVar;
 use Utopia\Migration\Resources\Functions\Func;
+use Utopia\Migration\Resources\Integrations\ApiKey;
 use Utopia\Migration\Resources\Integrations\Platform;
 use Utopia\Migration\Resources\Messaging\Message;
 use Utopia\Migration\Resources\Messaging\Provider;
@@ -239,6 +240,7 @@ class Appwrite extends Source
 
             // Integrations
             Resource::TYPE_PLATFORM,
+            Resource::TYPE_API_KEY,
         ];
     }
 
@@ -2234,18 +2236,27 @@ class Appwrite extends Source
      */
     private function reportIntegrations(array $resources, array &$report, array $resourceIds = []): void
     {
+        $consoleHeaders = $this->getConsoleHeaders();
+
+        if ($consoleHeaders === null) {
+            return;
+        }
+
         if (\in_array(Resource::TYPE_PLATFORM, $resources)) {
-            $consoleHeaders = $this->getConsoleHeaders();
-
-            if ($consoleHeaders === null) {
-                return;
-            }
-
             try {
                 $response = $this->call('GET', '/projects/' . $this->project . '/platforms', $consoleHeaders);
                 $report[Resource::TYPE_PLATFORM] = $response['total'] ?? 0;
             } catch (\Throwable) {
                 $report[Resource::TYPE_PLATFORM] = 0;
+            }
+        }
+
+        if (\in_array(Resource::TYPE_API_KEY, $resources)) {
+            try {
+                $response = $this->call('GET', '/projects/' . $this->project . '/keys', $consoleHeaders);
+                $report[Resource::TYPE_API_KEY] = $response['total'] ?? 0;
+            } catch (\Throwable) {
+                $report[Resource::TYPE_API_KEY] = 0;
             }
         }
     }
@@ -2285,6 +2296,14 @@ class Appwrite extends Source
                 Resource::TYPE_PLATFORM,
                 Transfer::GROUP_INTEGRATIONS,
                 $this->exportPlatforms(...)
+            );
+        }
+
+        if (\in_array(Resource::TYPE_API_KEY, $resources)) {
+            $this->exportWithConsoleHeaders(
+                Resource::TYPE_API_KEY,
+                Transfer::GROUP_INTEGRATIONS,
+                $this->exportApiKeys(...)
             );
         }
     }
@@ -2372,6 +2391,32 @@ class Appwrite extends Source
         }
 
         $this->callback($platforms);
+    }
+
+    private function exportApiKeys(array $consoleHeaders): void
+    {
+        $response = $this->call('GET', '/projects/' . $this->project . '/keys', $consoleHeaders);
+
+        if (empty($response['keys'])) {
+            return;
+        }
+
+        $apiKeys = [];
+
+        foreach ($response['keys'] as $key) {
+            $apiKeys[] = new ApiKey(
+                $key['$id'] ?? '',
+                $key['name'] ?? '',
+                $key['scopes'] ?? [],
+                $key['expire'] ?? '',
+                $key['accessedAt'] ?? '',
+                $key['sdks'] ?? [],
+                createdAt: $key['$createdAt'] ?? '',
+                updatedAt: $key['$updatedAt'] ?? '',
+            );
+        }
+
+        $this->callback($apiKeys);
     }
 
     /**

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -2243,16 +2243,15 @@ class Appwrite extends Source
         }
 
         if (\in_array(Resource::TYPE_API_KEY, $resources)) {
-            $consoleHeaders = $this->getConsoleHeaders();
-            if ($consoleHeaders === null) {
+            $keyQueries = $this->buildQueries(
+                resourceType: Resource::TYPE_API_KEY,
+                resourceIds: $resourceIds,
+                limit: 1
+            );
+            try {
+                $report[Resource::TYPE_API_KEY] = $this->project->listKeys($keyQueries)->total;
+            } catch (\Throwable) {
                 $report[Resource::TYPE_API_KEY] = 0;
-            } else {
-                try {
-                    $response = $this->call('GET', '/projects/' . $this->project . '/keys', $consoleHeaders);
-                    $report[Resource::TYPE_API_KEY] = $response['total'] ?? 0;
-                } catch (\Throwable) {
-                    $report[Resource::TYPE_API_KEY] = 0;
-                }
             }
         }
     }
@@ -2302,37 +2301,17 @@ class Appwrite extends Source
         }
 
         if (\in_array(Resource::TYPE_API_KEY, $resources)) {
-            $this->exportWithConsoleHeaders(
-                Resource::TYPE_API_KEY,
-                Transfer::GROUP_INTEGRATIONS,
-                $this->exportApiKeys(...)
-            );
-        }
-    }
-
-    protected function exportWithConsoleHeaders(string $resourceType, string $group, callable $callback): void
-    {
-        $consoleHeaders = $this->getConsoleHeaders();
-
-        if ($consoleHeaders === null) {
-            $this->addError(new Exception(
-                $resourceType,
-                $group,
-                message: 'Console key unavailable for source instance',
-            ));
-            return;
-        }
-
-        try {
-            $callback($consoleHeaders);
-        } catch (\Throwable $e) {
-            $this->addError(new Exception(
-                $resourceType,
-                $group,
-                message: $e->getMessage(),
-                code: $e->getCode(),
-                previous: $e
-            ));
+            try {
+                $this->exportApiKeys($batchSize);
+            } catch (\Throwable $e) {
+                $this->addError(new Exception(
+                    Resource::TYPE_API_KEY,
+                    Transfer::GROUP_INTEGRATIONS,
+                    message: $e->getMessage(),
+                    code: $e->getCode(),
+                    previous: $e
+                ));
+            }
         }
     }
 
@@ -2417,30 +2396,53 @@ class Appwrite extends Source
         }
     }
 
-    private function exportApiKeys(array $consoleHeaders): void
+    /**
+     * @throws AppwriteException
+     */
+    private function exportApiKeys(int $batchSize): void
     {
-        $response = $this->call('GET', '/projects/' . $this->project . '/keys', $consoleHeaders);
+        $lastId = null;
 
-        if (empty($response['keys'])) {
-            return;
+        while (true) {
+            $queries = [Query::limit($batchSize)];
+
+            if ($this->rootResourceId !== '' && $this->rootResourceType === Resource::TYPE_API_KEY) {
+                $queries[] = Query::equal('$id', $this->rootResourceId);
+                $queries[] = Query::limit(1);
+            }
+
+            if ($lastId !== null) {
+                $queries[] = Query::cursorAfter($lastId);
+            }
+
+            $response = $this->project->listKeys($queries);
+            if ($response->total === 0) {
+                break;
+            }
+
+            $apiKeys = [];
+
+            foreach ($response->keys as $key) {
+                $apiKeys[] = new ApiKey(
+                    $key->id,
+                    $key->name,
+                    $key->scopes,
+                    $key->expire,
+                    $key->accessedAt,
+                    $key->sdks,
+                    createdAt: $key->createdAt,
+                    updatedAt: $key->updatedAt,
+                );
+
+                $lastId = $key->id;
+            }
+
+            $this->callback($apiKeys);
+
+            if (\count($response->keys) < $batchSize) {
+                break;
+            }
         }
-
-        $apiKeys = [];
-
-        foreach ($response['keys'] as $key) {
-            $apiKeys[] = new ApiKey(
-                $key['$id'] ?? '',
-                $key['name'] ?? '',
-                $key['scopes'] ?? [],
-                $key['expire'] ?? '',
-                $key['accessedAt'] ?? '',
-                $key['sdks'] ?? [],
-                createdAt: $key['$createdAt'] ?? '',
-                updatedAt: $key['$updatedAt'] ?? '',
-            );
-        }
-
-        $this->callback($apiKeys);
     }
 
     /**

--- a/src/Migration/Transfer.php
+++ b/src/Migration/Transfer.php
@@ -60,6 +60,7 @@ class Transfer
 
     public const GROUP_INTEGRATIONS_RESOURCES = [
         Resource::TYPE_PLATFORM,
+        Resource::TYPE_API_KEY,
     ];
     public const GROUP_DOCUMENTSDB_RESOURCES = [
         Resource::TYPE_DATABASE_DOCUMENTSDB,
@@ -122,6 +123,7 @@ class Transfer
 
         // Integrations
         Resource::TYPE_PLATFORM,
+        Resource::TYPE_API_KEY,
 
         // legacy
         Resource::TYPE_DOCUMENT,
@@ -139,6 +141,7 @@ class Transfer
         Resource::TYPE_USER,
         Resource::TYPE_TEAM,
         Resource::TYPE_PLATFORM,
+        Resource::TYPE_API_KEY,
         Resource::TYPE_PROVIDER,
         Resource::TYPE_TOPIC,
         Resource::TYPE_MESSAGE,

--- a/tests/Migration/Unit/Adapters/MockDestination.php
+++ b/tests/Migration/Unit/Adapters/MockDestination.php
@@ -52,6 +52,7 @@ class MockDestination extends Destination
             Resource::TYPE_TEAM,
             Resource::TYPE_MEMBERSHIP,
             Resource::TYPE_PLATFORM,
+            Resource::TYPE_API_KEY,
             Resource::TYPE_PROVIDER,
             Resource::TYPE_TOPIC,
             Resource::TYPE_SUBSCRIBER,

--- a/tests/Migration/Unit/Adapters/MockSource.php
+++ b/tests/Migration/Unit/Adapters/MockSource.php
@@ -81,6 +81,7 @@ class MockSource extends Source
             Resource::TYPE_TEAM,
             Resource::TYPE_MEMBERSHIP,
             Resource::TYPE_PLATFORM,
+            Resource::TYPE_API_KEY,
             Resource::TYPE_PROVIDER,
             Resource::TYPE_TOPIC,
             Resource::TYPE_SUBSCRIBER,


### PR DESCRIPTION
## Summary

- Adds API key migration support for the Appwrite source/destination (new `ApiKey` resource, source export via console headers, destination import).
- Adds platform migration support (new `Platform` resource).
- Pulls in `feat-platform-db-access` (PR #154), which switches platform listing/export from console-key HTTP calls to the `Project` SDK service with `buildQueries`.

## Notes

- Platforms no longer require console headers — they go through `projectService->listPlatforms` / `exportPlatforms($batchSize)`.
- API keys still require console headers and continue to use the `exportWithConsoleHeaders` wrapper.
- Stacks on top of the platform-db-access work; if PR #154 lands first, this diff will shrink accordingly.

## Test plan

- [ ] `composer install && composer test` (vendor not present in worktree — please run locally)
- [ ] `composer lint && composer format`
- [ ] E2E: migrate a project with API keys + platforms from one Appwrite instance to another, verify both arrive
- [ ] Verify `report` totals for `apiKey` and `platform` resource types