### PR TITLE
Wrap user-facing throws in Sources/Appwrite as Migration\Exception

### DIFF
--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -138,7 +138,12 @@ class Appwrite extends Source
 
             case static::SOURCE_DATABASE:
                 if (\is_null($dbForProject)) {
-                    throw new \Exception('Database is required for database source', Exception::CODE_VALIDATION);
+                    throw new Exception(
+                        resourceName: '',
+                        resourceGroup: '',
+                        message: 'Database is required for database source',
+                        code: Exception::CODE_VALIDATION,
+                    );
                 }
                 $this->reader = new DatabaseReader(
                     $this->dbForProject,
@@ -148,7 +153,12 @@ class Appwrite extends Source
                 break;
 
             default:
-                throw new \Exception('Unknown source', Exception::CODE_VALIDATION);
+                throw new Exception(
+                    resourceName: '',
+                    resourceGroup: '',
+                    message: 'Unknown source',
+                    code: Exception::CODE_VALIDATION,
+                );
         }
     }
 
@@ -263,9 +273,21 @@ class Appwrite extends Source
             )['version'];
         } catch (\Throwable $e) {
             if ($e->getCode() === 403) {
-                throw new \Exception('Missing required scopes.', $e->getCode(), $e);
+                throw new Exception(
+                    resourceName: '',
+                    resourceGroup: '',
+                    message: 'Missing required scopes.',
+                    code: $e->getCode(),
+                    previous: $e,
+                );
             } else {
-                throw new \Exception($e->getMessage(), $e->getCode(), $e);
+                throw new Exception(
+                    resourceName: '',
+                    resourceGroup: '',
+                    message: $e->getMessage(),
+                    code: $e->getCode(),
+                    previous: $e,
+                );
             }
         }
 
@@ -725,7 +747,12 @@ class Appwrite extends Source
                 foreach ($response->memberships as $membership) {
                     $user = $cacheUsers[$membership->userId] ?? null;
                     if ($user === null) {
-                        throw new \Exception('User not found', Exception::CODE_NOT_FOUND);
+                        throw new Exception(
+                            resourceName: Resource::TYPE_MEMBERSHIP,
+                            resourceGroup: Transfer::GROUP_AUTH,
+                            message: 'User not found',
+                            code: Exception::CODE_NOT_FOUND,
+                        );
                     }
 
                     $memberships[] = new Membership(


### PR DESCRIPTION
## Summary

Four `throw new \Exception(...)` sites in `Sources/Appwrite` leak to Sentry through the migrations-worker outer catch. They're user-state / user-input causes — Sentry noise rather than engineering signal:

- **Setup** (`__construct`): `Database is required for database source`, `Unknown source`
- **`report()` catch**: `Missing required scopes.` (403), `<sdk-message>` for everything else — including the very common "Database reads limit for your organization has exceeded" (402) when the user is over their plan quota.
- **`exportTeamMemberships`**: `User not found` when a membership references a deleted user.

The worker's gate routes:
- `Appwrite\Extend\Exception` → arm 1 (registry-driven `isPublishable()`)
- `Utopia\Migration\Exception` → arm 2 (always suppressed; library is user-facing)
- anything else → arm 3 (publish)

Bare `\Exception` lands in arm 3 → Sentry. Wrapping in `Migration\Exception` lands in arm 2 → not Sentry, recorded on the migration document.

## What changed

`src/Migration/Sources/Appwrite.php` — four throws converted from bare `\Exception` to `Utopia\Migration\Exception`. Codes preserved (`CODE_VALIDATION`, `CODE_NOT_FOUND`, or the original code from the upstream throwable via `$e->getCode()`).

## Companion

Pairs with the worker-side gate changes already merged in `appwrite/appwrite#12226` (and follow-up `#12272`) plus `appwrite-labs/cloud#3962`. Those PRs route the worker's setup throws through arm 2; this PR closes the same loop for the library's source-side throws.
