### PR TITLE
fix(nhost): correctly handle text column size for varchar vs text types

### DIFF
--- a/src/Migration/Sources/NHost.php
+++ b/src/Migration/Sources/NHost.php
@@ -738,7 +738,7 @@ class NHost extends Source
                     required: $column['is_nullable'] === 'NO',
                     default: $column['column_default'],
                     array: $isArray,
-                    size: $column['character_maximum_length'] ?? $column['character_octet_length'] ?? 10485760,
+                    size: $column['character_maximum_length'] ?? ($column['data_type'] === 'text' ? 10485760 : ($column['character_octet_length'] ?? 10485760)),
                 );
         }
     }


### PR DESCRIPTION
## Problem

When importing from Supabase (which uses the NHost source), all text columns are imported with size 10485760 regardless of their actual type:

- For archar(n) columns: character_maximum_length is correctly set to 
.
- For 	ext columns: both character_maximum_length and character_octet_length are null, so the hardcoded fallback 10485760 is used.
- Additionally, character_octet_length returns the byte length (e.g., 1020 for archar(255) in UTF-8), not the character length, so using it as a fallback before character_maximum_length is misleading.

## Fix

The fix checks data_type === 'text' separately so that:
1. archar(n) columns: use character_maximum_length = 

2. 	ext columns: uses 10485760 as a reasonable default for unlimited text
3. character_octet_length is only used for other edge-case types

## Related

Fixes appwrite/appwrite#7182