### PR TITLE
fix: ignore unrequested row/document types in status counters

### DIFF
--- a/src/Migration/Transfer.php
+++ b/src/Migration/Transfer.php
@@ -251,6 +251,15 @@ class Transfer
         foreach ($this->cache->getAll() as $resourceType => $resources) {
             foreach ($resources as $k => $resource) {
                 if (($resourceType === Resource::TYPE_ROW || $resourceType === Resource::TYPE_DOCUMENT) && is_string($resource)) {
+                    // Only report status for resource types that were requested,
+                    // mirroring the isset() guard below. Row/document counts can be
+                    // aggregated into the cache for an unrequested type, which would
+                    // otherwise read an unseeded 'pending' key and leave a phantom,
+                    // non-empty counter.
+                    if (!isset($status[$resourceType])) {
+                        continue;
+                    }
+
                     $resource = intval($resource);
 
                     $status[$resourceType][$k] = $resource;

--- a/tests/Migration/Unit/General/TransferTest.php
+++ b/tests/Migration/Unit/General/TransferTest.php
@@ -5,6 +5,8 @@ namespace Utopia\Tests\Unit\General;
 use PHPUnit\Framework\TestCase;
 use Utopia\Migration\Resource;
 use Utopia\Migration\Resources\Database\Database;
+use Utopia\Migration\Resources\Database\Row;
+use Utopia\Migration\Resources\Database\Table;
 use Utopia\Migration\Transfer;
 use Utopia\Tests\Unit\Adapters\MockDestination;
 use Utopia\Tests\Unit\Adapters\MockSource;
@@ -63,5 +65,30 @@ class TransferTest extends TestCase
         $this->assertNotNull($database);
         $this->assertSame('test', $database->getDatabaseName());
         $this->assertSame('test', $database->getId());
+    }
+
+    /**
+     * Row and document counts are aggregated into the cache by status. When such
+     * a count exists for a resource type that was not part of the migration
+     * request, getStatusCounters() must ignore it, exactly as it already does for
+     * non-row resources via the isset() guard. Otherwise it reads an unseeded
+     * 'pending' key (triggering an "Undefined array key" warning) and reports a
+     * phantom, non-empty counter for a type the caller never asked to migrate.
+     */
+    public function testStatusCountersIgnoreUnrequestedRowCounts(): void
+    {
+        // No resource types were requested, so 'row'/'document' are unrequested.
+        // A row count still leaks into the cache: the destination tallies row and
+        // document counts by status as it imports them.
+        $table = new Table(new Database('db', 'db'), 'table', 'table');
+        $row = new Row('row-1', $table);
+        $row->setStatus(Resource::STATUS_SUCCESS);
+
+        $this->transfer->getCache()->add($row);
+
+        $counters = $this->transfer->getStatusCounters();
+
+        $this->assertArrayNotHasKey(Resource::TYPE_ROW, $counters);
+        $this->assertSame([], $counters);
     }
 }


### PR DESCRIPTION
## Problem

`Transfer::getStatusCounters()` seeds a status bucket only for **requested** resource types, and the non-row branch correctly guards with `if (isset($status[$resource->getName()]))` so it ignores resource types that weren't requested.

The **row/document branch had no such guard**. Row and document counts are aggregated into the cache by status (`cache['row'][$status] = "count"`), and that cache can contain a row/document entry for a type that was **not** part of the migration request (e.g. a stray/skipped document the destination still tallied). When that happens, the branch:

1. auto-vivifies `$status[$resourceType][$k]`,
2. reads `$status[$resourceType]['pending']` on a bucket that was never seeded → **`Undefined array key "pending"` warning**, and
3. leaves a phantom, non-zero entry that survives the "remove all empty resources" prune.

The result is a non-empty `statusCounters` after an otherwise clean migration. Downstream (Appwrite server-ce / cloud) this surfaced as a **flaky `assertEmpty($statusCounters)`** in the Appwrite→Appwrite migration e2e test, failing intermittently across unrelated PRs.

## Fix

Add the same `isset($status[$resourceType])` guard the non-row branch already uses, so unrequested row/document counts are ignored consistently. No behaviour change for requested row/document types.

## Test

`TransferTest::testStatusCountersIgnoreUnrequestedRowCounts` adds a row count to the cache for a type that was not requested and asserts `getStatusCounters()` ignores it and returns `[]`.

- Without the fix: fails with `Failed asserting that an array does not have the key 'row'` plus the `Undefined array key "pending"` warning.
- With the fix: passes.

Verified locally: full Unit suite green, `composer lint` (Pint) clean, PHPStan clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)