### PR TITLE
Update PHP SDK to 26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-curl": "*",
         "ext-openssl": "*",
 
-        "appwrite/appwrite": "24.*",
+        "appwrite/appwrite": "^26.0",
         "utopia-php/database": "5.*",
         "utopia-php/storage": "2.*",
         "utopia-php/dsn": "0.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d500f176f703c97758a1fc200f0ace55",
+    "content-hash": "1eab1f63068b4695ce48da1faf488c98",
     "packages": [
         {
             "name": "appwrite/appwrite",
-            "version": "24.1.0",
+            "version": "26.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-for-php.git",
-                "reference": "dcb3550a3332de1c1665a015a09e9c73ff515e4f"
+                "reference": "bc26d0f0cfa4699de12d6af4df70ac0729ab7918"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-for-php/zipball/dcb3550a3332de1c1665a015a09e9c73ff515e4f",
-                "reference": "dcb3550a3332de1c1665a015a09e9c73ff515e4f",
+                "url": "https://api.github.com/repos/appwrite/sdk-for-php/zipball/bc26d0f0cfa4699de12d6af4df70ac0729ab7918",
+                "reference": "bc26d0f0cfa4699de12d6af4df70ac0729ab7918",
                 "shasum": ""
             },
             "require": {
@@ -27,7 +27,7 @@
             },
             "require-dev": {
                 "mockery/mockery": "1.6.12",
-                "phpunit/phpunit": "^10"
+                "phpunit/phpunit": "^12"
             },
             "type": "library",
             "autoload": {
@@ -43,10 +43,10 @@
             "support": {
                 "email": "team@appwrite.io",
                 "issues": "https://github.com/appwrite/sdk-for-php/issues",
-                "source": "https://github.com/appwrite/sdk-for-php/tree/24.1.0",
+                "source": "https://github.com/appwrite/sdk-for-php/tree/26.0.0",
                 "url": "https://appwrite.io/support"
             },
-            "time": "2026-05-20T09:37:03+00:00"
+            "time": "2026-06-17T04:32:07+00:00"
         },
         {
             "name": "brick/math",

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2073,6 +2073,7 @@ class Appwrite extends Destination
                 "/storage/buckets/{$bucketId}/files",
                 [
                     'content-type' => 'multipart/form-data',
+                    'X-Appwrite-Project' => $this->projectId,
                 ],
                 [
                     'bucketId' => $bucketId,
@@ -2094,6 +2095,7 @@ class Appwrite extends Destination
             [
                 'content-type' => 'multipart/form-data',
                 'content-range' => 'bytes ' . ($file->getStart()) . '-' . ($file->getEnd() == ($file->getSize() - 1) ? $file->getSize() : $file->getEnd()) . '/' . $file->getSize(),
+                'X-Appwrite-Project' => $this->projectId,
             ],
             [
                 'bucketId' => $bucketId,
@@ -2435,6 +2437,7 @@ class Appwrite extends Destination
                 "/functions/{$functionId}/deployments",
                 [
                     'content-type' => 'multipart/form-data',
+                    'X-Appwrite-Project' => $this->projectId,
                 ],
                 [
                     'functionId' => $functionId,
@@ -2456,6 +2459,7 @@ class Appwrite extends Destination
                 'content-type' => 'multipart/form-data',
                 'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . ($deployment->getEnd() == ($deployment->getSize() - 1) ? $deployment->getSize() : $deployment->getEnd()) . '/' . $deployment->getSize(),
                 'x-appwrite-id' => $deployment->getId(),
+                'X-Appwrite-Project' => $this->projectId,
             ],
             [
                 'functionId' => $functionId,
@@ -3066,6 +3070,7 @@ class Appwrite extends Destination
                 "/sites/{$siteId}/deployments",
                 [
                     'content-type' => 'multipart/form-data',
+                    'X-Appwrite-Project' => $this->projectId,
                 ],
                 [
                     'siteId' => $siteId,
@@ -3090,6 +3095,7 @@ class Appwrite extends Destination
                 'content-type' => 'multipart/form-data',
                 'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . ($deployment->getEnd() == ($deployment->getSize() - 1) ? $deployment->getSize() : $deployment->getEnd()) . '/' . $deployment->getSize(),
                 'x-appwrite-id' => $deployment->getId(),
+                'X-Appwrite-Project' => $this->projectId,
             ],
             [
                 'siteId' => $siteId,

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -3379,11 +3379,11 @@ class Appwrite extends Destination
 
                 case 'redirect':
                     $statusCode = match ($resource->getRedirectStatusCode()) {
-                        301 => StatusCode::MOVEDPERMANENTLY301(),
-                        302 => StatusCode::FOUND302(),
-                        307 => StatusCode::TEMPORARYREDIRECT307(),
-                        308 => StatusCode::PERMANENTREDIRECT308(),
-                        default => StatusCode::MOVEDPERMANENTLY301(),
+                        301 => StatusCode::MOVEDPERMANENTLY(),
+                        302 => StatusCode::FOUND(),
+                        307 => StatusCode::TEMPORARYREDIRECT(),
+                        308 => StatusCode::PERMANENTREDIRECT(),
+                        default => StatusCode::MOVEDPERMANENTLY(),
                     };
 
                     $resourceType = $deploymentResourceType === 'site'

--- a/src/Migration/Sources/Appwrite/Reader/Database.php
+++ b/src/Migration/Sources/Appwrite/Reader/Database.php
@@ -81,15 +81,18 @@ class Database implements Reader
 
         $dbResources = [];
         $databases = $this->listDatabases($databaseQueries);
+        $selectedDatabaseTypes = \array_intersect($resources, array_keys(Resource::DATABASE_TYPE_RESOURCE_MAP));
 
         foreach ($databases as $database) {
-            $databaseType = $database->getAttribute('type');
-            if (in_array($databaseType, [Resource::TYPE_DATABASE_LEGACY,Resource::TYPE_DATABASE_TABLESDB])) {
-                $databaseType = Resource::TYPE_DATABASE;
+            $databaseType = $this->getDatabaseType($database);
+
+            if (
+                !empty($selectedDatabaseTypes) &&
+                !Resource::isSupported($databaseType, $selectedDatabaseTypes)
+            ) {
+                continue;
             }
-            if (!isset(Resource::DATABASE_TYPE_RESOURCE_MAP[$databaseType])) {
-                $databaseType = Resource::TYPE_DATABASE;
-            }
+
             if (Resource::isSupported($databaseType, $resources)) {
                 $report[$databaseType] += 1;
             }
@@ -97,13 +100,13 @@ class Database implements Reader
 
         // Process each database
         foreach ($databases as $database) {
-            $databaseType = $database->getAttribute('type', Resource::TYPE_DATABASE);
-            if (\in_array($databaseType, [Resource::TYPE_DATABASE_LEGACY, Resource::TYPE_DATABASE_TABLESDB], true)) {
-                $databaseType = Resource::TYPE_DATABASE;
-            }
+            $databaseType = $this->getDatabaseType($database);
 
-            if (!isset(Resource::DATABASE_TYPE_RESOURCE_MAP[$databaseType])) {
-                $databaseType = Resource::TYPE_DATABASE;
+            if (
+                !empty($selectedDatabaseTypes) &&
+                !Resource::isSupported($databaseType, $selectedDatabaseTypes)
+            ) {
+                continue;
             }
 
             $databaseSpecificResources = Resource::DATABASE_TYPE_RESOURCE_MAP[$databaseType];
@@ -137,7 +140,7 @@ class Database implements Reader
 
                 if (Resource::isSupported($databaseSpecificResources['record'], $resources)) {
                     $rowTableId = "database_{$databaseSequence}_collection_{$tableSequence}";
-                    $count = $this->countResources($rowTableId, [], $dbResource);
+                    $count = $this->countResources($rowTableId, [], $database);
                     $report[$databaseSpecificResources['record']] += $count;
                 }
 
@@ -351,7 +354,7 @@ class Database implements Reader
         $tableId = "database_{$database->getSequence()}_collection_{$table->getSequence()}";
 
         // Use the appropriate database instance for this specific database
-        $dbInstance = $this->getDatabase($resource->getDatabase()->getDatabase());
+        $dbInstance = $this->getDatabase($database);
 
         try {
             $rows = $dbInstance->find($tableId, $queries);
@@ -404,7 +407,7 @@ class Database implements Reader
         $tableId = "database_{$database->getSequence()}_collection_{$table->getSequence()}";
 
         // Use the appropriate database instance for this specific database
-        $dbInstance = $this->getDatabase($resource->getDatabase()->getDatabase());
+        $dbInstance = $this->getDatabase($database);
 
         return $dbInstance->getDocument(
             $tableId,
@@ -495,14 +498,14 @@ class Database implements Reader
     /**
      * @param string $table
      * @param array $queries
-     * @param DatabaseResource|null $databaseResource
+     * @param UtopiaDocument|null $database
      * @return int
      */
-    private function countResources(string $table, array $queries = [], ?DatabaseResource $databaseResource = null): int
+    private function countResources(string $table, array $queries = [], ?UtopiaDocument $database = null): int
     {
         // Use the appropriate database instance for row data
-        if ($databaseResource !== null) {
-            $dbInstance = $this->getDatabase($databaseResource->getDatabase());
+        if ($database !== null) {
+            $dbInstance = $this->getDatabase($database);
             return $dbInstance->count($table, $queries);
         }
 
@@ -510,15 +513,27 @@ class Database implements Reader
         return $this->dbForProject->count($table, $queries);
     }
 
-    /**
-     * Get the appropriate database instance for the given database DSN
-     */
-    private function getDatabase(?string $databaseDSN = null): UtopiaDatabase
+    private function getDatabase(?UtopiaDocument $database = null): UtopiaDatabase
     {
-        if ($this->getDatabasesDB !== null && $databaseDSN !== null) {
-            return ($this->getDatabasesDB)(new UtopiaDocument(['database' => $databaseDSN]));
+        if ($this->getDatabasesDB !== null && $database !== null) {
+            return ($this->getDatabasesDB)($database);
         }
 
         return $this->dbForProject;
+    }
+
+    private function getDatabaseType(UtopiaDocument $database): string
+    {
+        $databaseType = $database->getAttribute('type', Resource::TYPE_DATABASE);
+
+        if (\in_array($databaseType, [Resource::TYPE_DATABASE_LEGACY, Resource::TYPE_DATABASE_TABLESDB], true)) {
+            return Resource::TYPE_DATABASE;
+        }
+
+        if (!isset(Resource::DATABASE_TYPE_RESOURCE_MAP[$databaseType])) {
+            return Resource::TYPE_DATABASE;
+        }
+
+        return $databaseType;
     }
 }


### PR DESCRIPTION
## Summary

- Update `appwrite/appwrite` dependency constraint to `^26.0` and lock to `26.0.0`.
- Adjust redirect status code enum calls for PHP SDK 26 compatibility.

## Testing

- `composer lint`
- `composer check`
- `composer test` (fails in NHost/Supabase E2E setup because DB was offline after 5 tries)
