### PR TITLE
Fix split database metadata reads

### DIFF
--- a/src/Migration/Sources/Appwrite/Reader/Database.php
+++ b/src/Migration/Sources/Appwrite/Reader/Database.php
@@ -153,12 +153,12 @@ class Database implements Reader
                     isset($databaseSpecificResources['field']) &&
                     Resource::isSupported($databaseSpecificResources['field'], $resources)
                 ) {
-                    $count = $this->countResources('attributes', $commonQueries);
+                    $count = $this->countResources('attributes', $commonQueries, $database);
                     $report[$databaseSpecificResources['field']] += $count;
                 }
 
                 if (in_array(Resource::TYPE_INDEX, $resources)) {
-                    $report[Resource::TYPE_INDEX] += $this->countResources('indexes', $commonQueries);
+                    $report[Resource::TYPE_INDEX] += $this->countResources('indexes', $commonQueries, $database);
                 }
             }
         }
@@ -196,7 +196,7 @@ class Database implements Reader
         }
 
         try {
-            return $this->dbForProject->find(
+            return $this->getDatabase($database)->find(
                 'database_' . $database->getSequence(),
                 $queries
             );
@@ -228,7 +228,9 @@ class Database implements Reader
             );
         }
 
-        $table = $this->dbForProject->getDocument(
+        $dbInstance = $this->getDatabase($database);
+
+        $table = $dbInstance->getDocument(
             'database_' . $database->getSequence(),
             $resource->getId(),
         );
@@ -246,7 +248,7 @@ class Database implements Reader
         $queries[] = Query::equal('collectionInternalId', [$table->getSequence()]);
 
         try {
-            $columns = $this->dbForProject->find('attributes', $queries);
+            $columns = $dbInstance->find('attributes', $queries);
         } catch (DatabaseException $e) {
             throw new Exception(
                 resourceName: $resource->getName(),
@@ -290,7 +292,9 @@ class Database implements Reader
             );
         }
 
-        $table = $this->dbForProject->getDocument(
+        $dbInstance = $this->getDatabase($database);
+
+        $table = $dbInstance->getDocument(
             'database_' . $database->getSequence(),
             $resource->getId(),
         );
@@ -308,7 +312,7 @@ class Database implements Reader
         $queries[] = Query::equal('collectionInternalId', [$table->getSequence()]);
 
         try {
-            return $this->dbForProject->find('indexes', $queries);
+            return $dbInstance->find('indexes', $queries);
         } catch (DatabaseException $e) {
             throw new Exception(
                 resourceName: $resource->getName(),
@@ -337,7 +341,9 @@ class Database implements Reader
             );
         }
 
-        $table = $this->dbForProject->getDocument(
+        $dbInstance = $this->getDatabase($database);
+
+        $table = $dbInstance->getDocument(
             'database_' . $database->getSequence(),
             $resource->getId(),
         );
@@ -352,9 +358,6 @@ class Database implements Reader
         }
 
         $tableId = "database_{$database->getSequence()}_collection_{$table->getSequence()}";
-
-        // Use the appropriate database instance for this specific database
-        $dbInstance = $this->getDatabase($database);
 
         try {
             $rows = $dbInstance->find($tableId, $queries);
@@ -390,7 +393,9 @@ class Database implements Reader
             );
         }
 
-        $table = $this->dbForProject->getDocument(
+        $dbInstance = $this->getDatabase($database);
+
+        $table = $dbInstance->getDocument(
             'database_' . $database->getSequence(),
             $resource->getId(),
         );
@@ -405,9 +410,6 @@ class Database implements Reader
         }
 
         $tableId = "database_{$database->getSequence()}_collection_{$table->getSequence()}";
-
-        // Use the appropriate database instance for this specific database
-        $dbInstance = $this->getDatabase($database);
 
         return $dbInstance->getDocument(
             $tableId,

--- a/tests/Migration/Unit/Sources/AppwriteDatabaseReaderTest.php
+++ b/tests/Migration/Unit/Sources/AppwriteDatabaseReaderTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Utopia\Tests\Unit\Sources;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database as UtopiaDatabase;
+use Utopia\Database\Document as UtopiaDocument;
+use Utopia\Database\Query;
+use Utopia\Migration\Resource;
+use Utopia\Migration\Sources\Appwrite\Reader\Database;
+
+class AppwriteDatabaseReaderTest extends TestCase
+{
+    public function testReportReadsDocumentsDbMetadataFromDatabaseConnection(): void
+    {
+        $database = new UtopiaDocument([
+            '$id' => 'documents',
+            '$sequence' => '2',
+            'name' => 'Documents',
+            '$createdAt' => '2026-01-01T00:00:00.000+00:00',
+            '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+            'enabled' => true,
+            'type' => Resource::TYPE_DATABASE_DOCUMENTSDB,
+            'database' => 'appwrite://database_selfhosted_fra1_2?database=appwrite&namespace=_1',
+        ]);
+
+        $collection = new UtopiaDocument([
+            '$id' => 'articles',
+            '$sequence' => '4',
+            'name' => 'Articles',
+            '$createdAt' => '2026-01-01T00:00:00.000+00:00',
+            '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+            'enabled' => true,
+        ]);
+
+        $dbForProject = $this->getMockBuilder(UtopiaDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['find', 'getDocument', 'count'])
+            ->getMock();
+
+        $dbForDatabase = $this->getMockBuilder(UtopiaDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['find', 'count'])
+            ->getMock();
+
+        $dbForProject
+            ->expects($this->once())
+            ->method('find')
+            ->with(
+                'databases',
+                $this->callback(fn (array $queries): bool => $this->hasEqualQuery($queries, '$id', ['documents']))
+            )
+            ->willReturn([$database]);
+
+        $dbForProject
+            ->expects($this->once())
+            ->method('getDocument')
+            ->with('databases', 'documents')
+            ->willReturn($database);
+
+        $dbForProject
+            ->expects($this->never())
+            ->method('count');
+
+        $dbForDatabase
+            ->expects($this->once())
+            ->method('find')
+            ->with('database_2', [])
+            ->willReturn([$collection]);
+
+        $dbForDatabase
+            ->expects($this->exactly(3))
+            ->method('count')
+            ->willReturnCallback(function (string $collection, array $queries): int {
+                return match ($collection) {
+                    'database_2_collection_4' => 7,
+                    'attributes' => $this->hasEqualQuery($queries, 'databaseInternalId', ['2'])
+                        && $this->hasEqualQuery($queries, 'collectionInternalId', ['4'])
+                            ? 2
+                            : 0,
+                    'indexes' => $this->hasEqualQuery($queries, 'databaseInternalId', ['2'])
+                        && $this->hasEqualQuery($queries, 'collectionInternalId', ['4'])
+                            ? 1
+                            : 0,
+                    default => 0,
+                };
+            });
+
+        $reader = new Database(
+            $dbForProject,
+            fn (UtopiaDocument $database): UtopiaDatabase => $dbForDatabase,
+        );
+
+        $report = [];
+        $reader->report(
+            [
+                Resource::TYPE_DATABASE_DOCUMENTSDB,
+                Resource::TYPE_COLLECTION,
+                Resource::TYPE_DOCUMENT,
+                Resource::TYPE_ATTRIBUTE,
+                Resource::TYPE_INDEX,
+            ],
+            $report,
+            [Resource::TYPE_DATABASE_DOCUMENTSDB => ['documents']]
+        );
+
+        $this->assertSame(1, $report[Resource::TYPE_DATABASE_DOCUMENTSDB]);
+        $this->assertSame(1, $report[Resource::TYPE_COLLECTION]);
+        $this->assertSame(7, $report[Resource::TYPE_DOCUMENT]);
+        $this->assertSame(2, $report[Resource::TYPE_ATTRIBUTE]);
+        $this->assertSame(1, $report[Resource::TYPE_INDEX]);
+    }
+
+    /**
+     * @param array<Query> $queries
+     * @param array<string> $values
+     */
+    private function hasEqualQuery(array $queries, string $attribute, array $values): bool
+    {
+        foreach ($queries as $query) {
+            if (
+                $query instanceof Query &&
+                $query->getMethod() === Query::TYPE_EQUAL &&
+                $query->getAttribute() === $attribute &&
+                $query->getValues() === $values
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## What
- read Appwrite table, attribute, and index metadata through the database-specific connection
- keep project DB reads scoped to the top-level `databases` collection
- add a regression test for DocumentsDB report counting with split database metadata

## Why
Cloud backup export workers on DB 6 can resolve a DocumentsDB database from the project DB, but the table metadata lives in the database-specific connection. Reading `database_<sequence>`, `attributes`, or `indexes` from the project DB leaves migration exports stuck/failing with `Collection not found`.

## Tests
- `composer lint`
- `composer check`
- `vendor/bin/phpunit --configuration phpunit.xml tests/Migration/Unit/Sources/AppwriteDatabaseReaderTest.php`
- `docker compose exec tests php vendor/bin/phpunit`