### PR TITLE
Fix empty split database metadata reports

### DIFF
--- a/src/Migration/Sources/Appwrite/Reader/Database.php
+++ b/src/Migration/Sources/Appwrite/Reader/Database.php
@@ -5,6 +5,7 @@ namespace Utopia\Migration\Sources\Appwrite\Reader;
 use Utopia\Database\Database as UtopiaDatabase;
 use Utopia\Database\Document as UtopiaDocument;
 use Utopia\Database\Exception as DatabaseException;
+use Utopia\Database\Exception\NotFound as DatabaseNotFoundException;
 use Utopia\Database\Query;
 use Utopia\Migration\Exception;
 use Utopia\Migration\Resource;
@@ -22,6 +23,8 @@ use Utopia\Migration\Sources\Appwrite\Reader;
  */
 class Database implements Reader
 {
+    private const COLLECTION_NOT_FOUND = 'Collection not found';
+
     /**
      * @var callable(UtopiaDocument|null): UtopiaDatabase
     */
@@ -201,6 +204,10 @@ class Database implements Reader
                 $queries
             );
         } catch (DatabaseException $e) {
+            if ($this->isMissingCollection($e)) {
+                return [];
+            }
+
             throw new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
@@ -250,6 +257,10 @@ class Database implements Reader
         try {
             $columns = $dbInstance->find('attributes', $queries);
         } catch (DatabaseException $e) {
+            if ($this->isMissingCollection($e)) {
+                return [];
+            }
+
             throw new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
@@ -314,6 +325,10 @@ class Database implements Reader
         try {
             return $dbInstance->find('indexes', $queries);
         } catch (DatabaseException $e) {
+            if ($this->isMissingCollection($e)) {
+                return [];
+            }
+
             throw new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
@@ -362,6 +377,10 @@ class Database implements Reader
         try {
             $rows = $dbInstance->find($tableId, $queries);
         } catch (DatabaseException $e) {
+            if ($this->isMissingCollection($e)) {
+                return [];
+            }
+
             throw new Exception(
                 resourceName: $resource->getName(),
                 resourceGroup: $resource->getGroup(),
@@ -508,7 +527,16 @@ class Database implements Reader
         // Use the appropriate database instance for row data
         if ($database !== null) {
             $dbInstance = $this->getDatabase($database);
-            return $dbInstance->count($table, $queries);
+
+            try {
+                return $dbInstance->count($table, $queries);
+            } catch (DatabaseException $e) {
+                if ($this->isMissingCollection($e)) {
+                    return 0;
+                }
+
+                throw $e;
+            }
         }
 
         // Use dbForProject for metadata tables
@@ -537,5 +565,10 @@ class Database implements Reader
         }
 
         return $databaseType;
+    }
+
+    private function isMissingCollection(DatabaseException $exception): bool
+    {
+        return $exception instanceof DatabaseNotFoundException && \strcasecmp($exception->getMessage(), self::COLLECTION_NOT_FOUND) === 0;
     }
 }

--- a/tests/Migration/Unit/Sources/AppwriteDatabaseReaderTest.php
+++ b/tests/Migration/Unit/Sources/AppwriteDatabaseReaderTest.php
@@ -5,8 +5,11 @@ namespace Utopia\Tests\Unit\Sources;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Database as UtopiaDatabase;
 use Utopia\Database\Document as UtopiaDocument;
+use Utopia\Database\Exception\NotFound as DatabaseNotFoundException;
 use Utopia\Database\Query;
 use Utopia\Migration\Resource;
+use Utopia\Migration\Resources\Database\Database as DatabaseResource;
+use Utopia\Migration\Resources\Database\Table as TableResource;
 use Utopia\Migration\Sources\Appwrite\Reader\Database;
 
 class AppwriteDatabaseReaderTest extends TestCase
@@ -109,6 +112,296 @@ class AppwriteDatabaseReaderTest extends TestCase
         $this->assertSame(7, $report[Resource::TYPE_DOCUMENT]);
         $this->assertSame(2, $report[Resource::TYPE_ATTRIBUTE]);
         $this->assertSame(1, $report[Resource::TYPE_INDEX]);
+    }
+
+    public function testReportTreatsMissingDocumentsDbCollectionTableAsEmpty(): void
+    {
+        $database = new UtopiaDocument([
+            '$id' => 'documents',
+            '$sequence' => '2',
+            'name' => 'Documents',
+            '$createdAt' => '2026-01-01T00:00:00.000+00:00',
+            '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+            'enabled' => true,
+            'type' => Resource::TYPE_DATABASE_DOCUMENTSDB,
+            'database' => 'appwrite://database_selfhosted_fra1_2?database=appwrite&namespace=_1',
+        ]);
+
+        $dbForProject = $this->getMockBuilder(UtopiaDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['find', 'getDocument'])
+            ->getMock();
+
+        $dbForDatabase = $this->getMockBuilder(UtopiaDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['find', 'count'])
+            ->getMock();
+
+        $dbForProject
+            ->expects($this->once())
+            ->method('find')
+            ->with(
+                'databases',
+                $this->callback(fn (array $queries): bool => $this->hasEqualQuery($queries, '$id', ['documents']))
+            )
+            ->willReturn([$database]);
+
+        $dbForProject
+            ->expects($this->once())
+            ->method('getDocument')
+            ->with('databases', 'documents')
+            ->willReturn($database);
+
+        $dbForDatabase
+            ->expects($this->once())
+            ->method('find')
+            ->with('database_2', [])
+            ->willThrowException(new DatabaseNotFoundException('Collection not found'));
+
+        $dbForDatabase
+            ->expects($this->never())
+            ->method('count');
+
+        $reader = new Database(
+            $dbForProject,
+            fn (UtopiaDocument $database): UtopiaDatabase => $dbForDatabase,
+        );
+
+        $report = [];
+        $reader->report(
+            [
+                Resource::TYPE_DATABASE_DOCUMENTSDB,
+                Resource::TYPE_COLLECTION,
+                Resource::TYPE_DOCUMENT,
+                Resource::TYPE_INDEX,
+            ],
+            $report,
+            [Resource::TYPE_DATABASE_DOCUMENTSDB => ['documents']]
+        );
+
+        $this->assertSame(1, $report[Resource::TYPE_DATABASE_DOCUMENTSDB]);
+        $this->assertSame(0, $report[Resource::TYPE_COLLECTION]);
+        $this->assertSame(0, $report[Resource::TYPE_DOCUMENT]);
+        $this->assertSame(0, $report[Resource::TYPE_INDEX]);
+    }
+
+    public function testReportTreatsMissingDocumentsDbIndexesTableAsEmpty(): void
+    {
+        $database = new UtopiaDocument([
+            '$id' => 'documents',
+            '$sequence' => '2',
+            'name' => 'Documents',
+            '$createdAt' => '2026-01-01T00:00:00.000+00:00',
+            '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+            'enabled' => true,
+            'type' => Resource::TYPE_DATABASE_DOCUMENTSDB,
+            'database' => 'appwrite://database_selfhosted_fra1_2?database=appwrite&namespace=_1',
+        ]);
+
+        $collection = new UtopiaDocument([
+            '$id' => 'articles',
+            '$sequence' => '4',
+            'name' => 'Articles',
+            '$createdAt' => '2026-01-01T00:00:00.000+00:00',
+            '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+            'enabled' => true,
+        ]);
+
+        $dbForProject = $this->getMockBuilder(UtopiaDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['find', 'getDocument'])
+            ->getMock();
+
+        $dbForDatabase = $this->getMockBuilder(UtopiaDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['find', 'count'])
+            ->getMock();
+
+        $dbForProject
+            ->expects($this->once())
+            ->method('find')
+            ->with(
+                'databases',
+                $this->callback(fn (array $queries): bool => $this->hasEqualQuery($queries, '$id', ['documents']))
+            )
+            ->willReturn([$database]);
+
+        $dbForProject
+            ->expects($this->once())
+            ->method('getDocument')
+            ->with('databases', 'documents')
+            ->willReturn($database);
+
+        $dbForDatabase
+            ->expects($this->once())
+            ->method('find')
+            ->with('database_2', [])
+            ->willReturn([$collection]);
+
+        $dbForDatabase
+            ->expects($this->exactly(2))
+            ->method('count')
+            ->willReturnCallback(function (string $collection, array $queries): int {
+                return match ($collection) {
+                    'database_2_collection_4' => 7,
+                    'indexes' => throw new DatabaseNotFoundException('collection not found'),
+                    default => 0,
+                };
+            });
+
+        $reader = new Database(
+            $dbForProject,
+            fn (UtopiaDocument $database): UtopiaDatabase => $dbForDatabase,
+        );
+
+        $report = [];
+        $reader->report(
+            [
+                Resource::TYPE_DATABASE_DOCUMENTSDB,
+                Resource::TYPE_COLLECTION,
+                Resource::TYPE_DOCUMENT,
+                Resource::TYPE_INDEX,
+            ],
+            $report,
+            [Resource::TYPE_DATABASE_DOCUMENTSDB => ['documents']]
+        );
+
+        $this->assertSame(1, $report[Resource::TYPE_DATABASE_DOCUMENTSDB]);
+        $this->assertSame(1, $report[Resource::TYPE_COLLECTION]);
+        $this->assertSame(7, $report[Resource::TYPE_DOCUMENT]);
+        $this->assertSame(0, $report[Resource::TYPE_INDEX]);
+    }
+
+    public function testListIndexesTreatsMissingIndexesTableAsEmpty(): void
+    {
+        $database = new UtopiaDocument([
+            '$id' => 'documents',
+            '$sequence' => '2',
+            'name' => 'Documents',
+            '$createdAt' => '2026-01-01T00:00:00.000+00:00',
+            '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+            'enabled' => true,
+            'type' => Resource::TYPE_DATABASE_DOCUMENTSDB,
+            'database' => 'appwrite://database_selfhosted_fra1_2?database=appwrite&namespace=_1',
+        ]);
+
+        $collection = new UtopiaDocument([
+            '$id' => 'articles',
+            '$sequence' => '4',
+            'name' => 'Articles',
+            '$createdAt' => '2026-01-01T00:00:00.000+00:00',
+            '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+            'enabled' => true,
+        ]);
+
+        $dbForProject = $this->getMockBuilder(UtopiaDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getDocument'])
+            ->getMock();
+
+        $dbForDatabase = $this->getMockBuilder(UtopiaDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getDocument', 'find'])
+            ->getMock();
+
+        $dbForProject
+            ->expects($this->once())
+            ->method('getDocument')
+            ->with('databases', 'documents')
+            ->willReturn($database);
+
+        $dbForDatabase
+            ->expects($this->once())
+            ->method('getDocument')
+            ->with('database_2', 'articles')
+            ->willReturn($collection);
+
+        $dbForDatabase
+            ->expects($this->once())
+            ->method('find')
+            ->with(
+                'indexes',
+                $this->callback(fn (array $queries): bool => $this->hasEqualQuery($queries, 'databaseInternalId', ['2'])
+                    && $this->hasEqualQuery($queries, 'collectionInternalId', ['4']))
+            )
+            ->willThrowException(new DatabaseNotFoundException('Collection not found'));
+
+        $reader = new Database(
+            $dbForProject,
+            fn (UtopiaDocument $database): UtopiaDatabase => $dbForDatabase,
+        );
+
+        $table = new TableResource(
+            new DatabaseResource('documents', 'Documents', type: Resource::TYPE_DATABASE_DOCUMENTSDB),
+            'Articles',
+            'articles'
+        );
+
+        $this->assertSame([], $reader->listIndexes($table));
+    }
+
+    public function testListRowsTreatsMissingRowTableAsEmpty(): void
+    {
+        $database = new UtopiaDocument([
+            '$id' => 'documents',
+            '$sequence' => '2',
+            'name' => 'Documents',
+            '$createdAt' => '2026-01-01T00:00:00.000+00:00',
+            '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+            'enabled' => true,
+            'type' => Resource::TYPE_DATABASE_DOCUMENTSDB,
+            'database' => 'appwrite://database_selfhosted_fra1_2?database=appwrite&namespace=_1',
+        ]);
+
+        $collection = new UtopiaDocument([
+            '$id' => 'articles',
+            '$sequence' => '4',
+            'name' => 'Articles',
+            '$createdAt' => '2026-01-01T00:00:00.000+00:00',
+            '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+            'enabled' => true,
+        ]);
+
+        $dbForProject = $this->getMockBuilder(UtopiaDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getDocument'])
+            ->getMock();
+
+        $dbForDatabase = $this->getMockBuilder(UtopiaDatabase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getDocument', 'find'])
+            ->getMock();
+
+        $dbForProject
+            ->expects($this->once())
+            ->method('getDocument')
+            ->with('databases', 'documents')
+            ->willReturn($database);
+
+        $dbForDatabase
+            ->expects($this->once())
+            ->method('getDocument')
+            ->with('database_2', 'articles')
+            ->willReturn($collection);
+
+        $dbForDatabase
+            ->expects($this->once())
+            ->method('find')
+            ->with('database_2_collection_4', [])
+            ->willThrowException(new DatabaseNotFoundException('Collection not found'));
+
+        $reader = new Database(
+            $dbForProject,
+            fn (UtopiaDocument $database): UtopiaDatabase => $dbForDatabase,
+        );
+
+        $table = new TableResource(
+            new DatabaseResource('documents', 'Documents', type: Resource::TYPE_DATABASE_DOCUMENTSDB),
+            'Articles',
+            'articles'
+        );
+
+        $this->assertSame([], $reader->listRows($table));
     }
 
     /**


### PR DESCRIPTION
## What\n- Treat missing split database metadata collections as empty during Appwrite database-source reports.\n- Add regressions for DocumentsDB reports with no collection metadata table and no indexes metadata table.\n\n## Why\nCloud Backups E2E for DocumentsDB archive reports can request the index resource even when the source collection has no indexes. With DB 6 / split DocumentsDB metadata, counting a missing indexes collection throws `Collection not found` and leaves the archive pending.\n\n## Validation\n- `vendor/bin/phpunit --configuration phpunit.xml tests/Migration/Unit/Sources/AppwriteDatabaseReaderTest.php`\n- `composer lint`\n- `composer check`\n- `docker compose exec tests php vendor/bin/phpunit`