### PR TITLE
Make Appwrite source report resilient to per-resource failures

### DIFF
--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -280,18 +280,8 @@ class Appwrite extends Source
             $resources = $this->getSupportedResources();
         }
 
+        // Reachability gate: unauthenticated, so a failure is a wrong/unreachable endpoint.
         try {
-            $this->reportAuth($resources, $report, $resourceIds);
-            $this->reportDatabases($resources, $report, $resourceIds);
-            $this->reportStorage($resources, $report, $resourceIds);
-            $this->reportFunctions($resources, $report, $resourceIds);
-            $this->reportMessaging($resources, $report, $resourceIds);
-            $this->reportSites($resources, $report, $resourceIds);
-            $this->reportIntegrations($resources, $report, $resourceIds);
-            $this->reportBackups($resources, $report, $resourceIds);
-            $this->reportProjects($resources, $report, $resourceIds);
-            $this->reportDomains($resources, $report, $resourceIds);
-
             $report['version'] = $this->call(
                 'GET',
                 '/health/version',
@@ -301,11 +291,52 @@ class Appwrite extends Source
                 ]
             )['version'];
         } catch (\Throwable $e) {
-            if ($e->getCode() === 403) {
-                throw new \Exception('Missing required scopes.', $e->getCode(), $e);
-            } else {
-                throw new \Exception($e->getMessage(), $e->getCode(), $e);
+            throw new \Exception('Unable to reach the migration source endpoint.', $e->getCode(), $e);
+        }
+
+        // Report groups independently: 404/unsupported is recorded and skipped; 401 and 403 surface.
+        $groups = [
+            Transfer::GROUP_AUTH => fn () => $this->reportAuth($resources, $report, $resourceIds),
+            Transfer::GROUP_DATABASES => fn () => $this->reportDatabases($resources, $report, $resourceIds),
+            Transfer::GROUP_STORAGE => fn () => $this->reportStorage($resources, $report, $resourceIds),
+            Transfer::GROUP_FUNCTIONS => fn () => $this->reportFunctions($resources, $report, $resourceIds),
+            Transfer::GROUP_MESSAGING => fn () => $this->reportMessaging($resources, $report, $resourceIds),
+            Transfer::GROUP_SITES => fn () => $this->reportSites($resources, $report, $resourceIds),
+            Transfer::GROUP_INTEGRATIONS => fn () => $this->reportIntegrations($resources, $report, $resourceIds),
+            Transfer::GROUP_BACKUPS => fn () => $this->reportBackups($resources, $report, $resourceIds),
+            Transfer::GROUP_PROJECTS => fn () => $this->reportProjects($resources, $report, $resourceIds),
+            Transfer::GROUP_DOMAINS => fn () => $this->reportDomains($resources, $report, $resourceIds),
+        ];
+
+        $missingScopes = [];
+
+        foreach ($groups as $group => $reporter) {
+            try {
+                $reporter();
+            } catch (\Throwable $e) {
+                $code = $e->getCode();
+
+                if ($code === Exception::CODE_UNAUTHORIZED) {
+                    throw new \Exception('Invalid credentials for the migration source.', $code, $e);
+                }
+
+                if ($code === Exception::CODE_FORBIDDEN) {
+                    $missingScopes[] = $group;
+                    continue;
+                }
+
+                $this->addError(new Exception(
+                    resourceName: $group,
+                    resourceGroup: $group,
+                    message: $e->getMessage(),
+                    code: $code ?: Exception::CODE_INTERNAL,
+                    previous: $e,
+                ));
             }
+        }
+
+        if (!empty($missingScopes)) {
+            throw new \Exception('Missing required scopes for: ' . \implode(', ', $missingScopes) . '.', Exception::CODE_FORBIDDEN);
         }
 
         $this->previousReport = $report;

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -294,8 +294,8 @@ class Appwrite extends Source
             throw new \Exception('Unable to reach the migration source endpoint.', $e->getCode(), $e);
         }
 
-        // Report groups independently: an unsupported resource (404) is skipped; missing scopes
-        // (403) and any other failure (invalid key, rate limit, server, connectivity) are surfaced.
+        // Report groups independently. A missing scope (403) is collected and surfaced together;
+        // any other failure fails the report.
         $groups = [
             Transfer::GROUP_AUTH => fn () => $this->reportAuth($resources, $report, $resourceIds),
             Transfer::GROUP_DATABASES => fn () => $this->reportDatabases($resources, $report, $resourceIds),
@@ -316,12 +316,12 @@ class Appwrite extends Source
                 $reporter();
             } catch (\Throwable $e) {
                 // Missing scope is user-fixable — collect every affected group and report together.
-                if ($e->getCode() === Exception::CODE_FORBIDDEN) {
-                    $missingScopes[] = $group;
-                    continue;
+                // Any other failure fails the report rather than returning partial counts.
+                if ($e->getCode() !== Exception::CODE_FORBIDDEN) {
+                    throw $e;
                 }
 
-                $this->rethrowUnlessUnsupported($e);
+                $missingScopes[] = $group;
             }
         }
 
@@ -335,13 +335,12 @@ class Appwrite extends Source
     }
 
     /**
-     * Re-throw unless the source simply does not support the resource (404). Optional resources
-     * then degrade to an empty count, while real failures — missing scope, rate limit, server
-     * error, connectivity — propagate and fail the report instead of returning partial data.
+     * Surface a missing-scope (403) failure from an optional reporter so report() can aggregate it;
+     * other failures are left for the caller to swallow to a zero count.
      */
-    private function rethrowUnlessUnsupported(\Throwable $e): void
+    private function rethrowIfForbidden(\Throwable $e): void
     {
-        if ($e->getCode() !== Exception::CODE_NOT_FOUND) {
+        if ($e->getCode() === Exception::CODE_FORBIDDEN) {
             throw $e;
         }
     }
@@ -1685,7 +1684,7 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_RULE] = $this->proxy->listRules([Query::limit(1)])->total;
             } catch (\Throwable $e) {
-                $this->rethrowUnlessUnsupported($e);
+                $this->rethrowIfForbidden($e);
                 $report[Resource::TYPE_RULE] = 0;
             }
         }
@@ -1702,7 +1701,7 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_PROJECT_VARIABLE] = $this->project->listVariables($variableQueries)->total;
             } catch (\Throwable $e) {
-                $this->rethrowUnlessUnsupported($e);
+                $this->rethrowIfForbidden($e);
                 $report[Resource::TYPE_PROJECT_VARIABLE] = 0;
             }
         }
@@ -1727,7 +1726,7 @@ class Appwrite extends Source
                 // total:true returns the real count without fetching every row.
                 $report[Resource::TYPE_PROJECT_EMAIL_TEMPLATE] = $this->project->listEmailTemplates([Query::limit(1)], total: true)->total;
             } catch (\Throwable $e) {
-                $this->rethrowUnlessUnsupported($e);
+                $this->rethrowIfForbidden($e);
                 $report[Resource::TYPE_PROJECT_EMAIL_TEMPLATE] = 0;
             }
         }
@@ -2884,7 +2883,7 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_PLATFORM] = $this->project->listPlatforms($platformQueries)->total;
             } catch (\Throwable $e) {
-                $this->rethrowUnlessUnsupported($e);
+                $this->rethrowIfForbidden($e);
                 $report[Resource::TYPE_PLATFORM] = 0;
             }
         }
@@ -2898,7 +2897,7 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_API_KEY] = $this->project->listKeys($keyQueries)->total;
             } catch (\Throwable $e) {
-                $this->rethrowUnlessUnsupported($e);
+                $this->rethrowIfForbidden($e);
                 $report[Resource::TYPE_API_KEY] = 0;
             }
         }
@@ -2912,7 +2911,7 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_WEBHOOK] = $this->webhooks->list($webhookQueries)->total;
             } catch (\Throwable $e) {
-                $this->rethrowUnlessUnsupported($e);
+                $this->rethrowIfForbidden($e);
                 $report[Resource::TYPE_WEBHOOK] = 0;
             }
         }

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -294,24 +294,26 @@ class Appwrite extends Source
             throw new \Exception('Unable to reach the migration source endpoint.', $e->getCode(), $e);
         }
 
-        $groups = [
-            Transfer::GROUP_AUTH => fn () => $this->reportAuth($resources, $report, $resourceIds),
-            Transfer::GROUP_DATABASES => fn () => $this->reportDatabases($resources, $report, $resourceIds),
-            Transfer::GROUP_STORAGE => fn () => $this->reportStorage($resources, $report, $resourceIds),
-            Transfer::GROUP_FUNCTIONS => fn () => $this->reportFunctions($resources, $report, $resourceIds),
-            Transfer::GROUP_MESSAGING => fn () => $this->reportMessaging($resources, $report, $resourceIds),
-            Transfer::GROUP_SITES => fn () => $this->reportSites($resources, $report, $resourceIds),
-            Transfer::GROUP_INTEGRATIONS => fn () => $this->reportIntegrations($resources, $report, $resourceIds),
-            Transfer::GROUP_BACKUPS => fn () => $this->reportBackups($resources, $report, $resourceIds),
-            Transfer::GROUP_PROJECTS => fn () => $this->reportProjects($resources, $report, $resourceIds),
-            Transfer::GROUP_DOMAINS => fn () => $this->reportDomains($resources, $report, $resourceIds),
+        // First-class callables (not fn()) so $report is passed by reference at call time;
+        // arrow functions would capture a copy and discard each reporter's writes.
+        $reporters = [
+            Transfer::GROUP_AUTH => $this->reportAuth(...),
+            Transfer::GROUP_DATABASES => $this->reportDatabases(...),
+            Transfer::GROUP_STORAGE => $this->reportStorage(...),
+            Transfer::GROUP_FUNCTIONS => $this->reportFunctions(...),
+            Transfer::GROUP_MESSAGING => $this->reportMessaging(...),
+            Transfer::GROUP_SITES => $this->reportSites(...),
+            Transfer::GROUP_INTEGRATIONS => $this->reportIntegrations(...),
+            Transfer::GROUP_BACKUPS => $this->reportBackups(...),
+            Transfer::GROUP_PROJECTS => $this->reportProjects(...),
+            Transfer::GROUP_DOMAINS => $this->reportDomains(...),
         ];
 
         $missingScopes = [];
 
-        foreach ($groups as $group => $reporter) {
+        foreach ($reporters as $group => $reporter) {
             try {
-                $reporter();
+                $reporter($resources, $report, $resourceIds);
             } catch (\Throwable $e) {
                 $code = $e->getCode();
 

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -294,8 +294,6 @@ class Appwrite extends Source
             throw new \Exception('Unable to reach the migration source endpoint.', $e->getCode(), $e);
         }
 
-        // Report groups independently. A missing scope (403) is collected and surfaced together;
-        // any other failure fails the report.
         $groups = [
             Transfer::GROUP_AUTH => fn () => $this->reportAuth($resources, $report, $resourceIds),
             Transfer::GROUP_DATABASES => fn () => $this->reportDatabases($resources, $report, $resourceIds),
@@ -315,8 +313,7 @@ class Appwrite extends Source
             try {
                 $reporter();
             } catch (\Throwable $e) {
-                // Missing scope is user-fixable — collect every affected group and report together.
-                // Any other failure fails the report rather than returning partial counts.
+                // Collect missing-scope (403) failures to surface together; any other error fails the report.
                 if ($e->getCode() !== Exception::CODE_FORBIDDEN) {
                     throw $e;
                 }
@@ -334,10 +331,7 @@ class Appwrite extends Source
         return $report;
     }
 
-    /**
-     * Surface a missing-scope (403) failure from an optional reporter so report() can aggregate it;
-     * other failures are left for the caller to swallow to a zero count.
-     */
+    /** Re-throw a 403 so report() can aggregate it as a missing scope; the caller swallows other errors. */
     private function rethrowIfForbidden(\Throwable $e): void
     {
         if ($e->getCode() === Exception::CODE_FORBIDDEN) {

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -294,7 +294,8 @@ class Appwrite extends Source
             throw new \Exception('Unable to reach the migration source endpoint.', $e->getCode(), $e);
         }
 
-        // Report groups independently: 404/unsupported is recorded and skipped; 401 and 403 surface.
+        // Report groups independently: an unsupported resource (404) is skipped; missing scopes
+        // (403) and any other failure (invalid key, rate limit, server, connectivity) are surfaced.
         $groups = [
             Transfer::GROUP_AUTH => fn () => $this->reportAuth($resources, $report, $resourceIds),
             Transfer::GROUP_DATABASES => fn () => $this->reportDatabases($resources, $report, $resourceIds),
@@ -314,24 +315,13 @@ class Appwrite extends Source
             try {
                 $reporter();
             } catch (\Throwable $e) {
-                $code = $e->getCode();
-
-                if ($code === Exception::CODE_UNAUTHORIZED) {
-                    throw new \Exception('Invalid credentials for the migration source.', $code, $e);
-                }
-
-                if ($code === Exception::CODE_FORBIDDEN) {
+                // Missing scope is user-fixable — collect every affected group and report together.
+                if ($e->getCode() === Exception::CODE_FORBIDDEN) {
                     $missingScopes[] = $group;
                     continue;
                 }
 
-                $this->addError(new Exception(
-                    resourceName: $group,
-                    resourceGroup: $group,
-                    message: $e->getMessage(),
-                    code: $code ?: Exception::CODE_INTERNAL,
-                    previous: $e,
-                ));
+                $this->rethrowUnlessUnsupported($e);
             }
         }
 
@@ -342,6 +332,18 @@ class Appwrite extends Source
         $this->previousReport = $report;
 
         return $report;
+    }
+
+    /**
+     * Re-throw unless the source simply does not support the resource (404). Optional resources
+     * then degrade to an empty count, while real failures — missing scope, rate limit, server
+     * error, connectivity — propagate and fail the report instead of returning partial data.
+     */
+    private function rethrowUnlessUnsupported(\Throwable $e): void
+    {
+        if ($e->getCode() !== Exception::CODE_NOT_FOUND) {
+            throw $e;
+        }
     }
 
     /**
@@ -1682,7 +1684,8 @@ class Appwrite extends Source
         if (\in_array(Resource::TYPE_RULE, $resources)) {
             try {
                 $report[Resource::TYPE_RULE] = $this->proxy->listRules([Query::limit(1)])->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                $this->rethrowUnlessUnsupported($e);
                 $report[Resource::TYPE_RULE] = 0;
             }
         }
@@ -1698,7 +1701,8 @@ class Appwrite extends Source
             );
             try {
                 $report[Resource::TYPE_PROJECT_VARIABLE] = $this->project->listVariables($variableQueries)->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                $this->rethrowUnlessUnsupported($e);
                 $report[Resource::TYPE_PROJECT_VARIABLE] = 0;
             }
         }
@@ -1722,7 +1726,8 @@ class Appwrite extends Source
             try {
                 // total:true returns the real count without fetching every row.
                 $report[Resource::TYPE_PROJECT_EMAIL_TEMPLATE] = $this->project->listEmailTemplates([Query::limit(1)], total: true)->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                $this->rethrowUnlessUnsupported($e);
                 $report[Resource::TYPE_PROJECT_EMAIL_TEMPLATE] = 0;
             }
         }
@@ -2878,7 +2883,8 @@ class Appwrite extends Source
             );
             try {
                 $report[Resource::TYPE_PLATFORM] = $this->project->listPlatforms($platformQueries)->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                $this->rethrowUnlessUnsupported($e);
                 $report[Resource::TYPE_PLATFORM] = 0;
             }
         }
@@ -2891,7 +2897,8 @@ class Appwrite extends Source
             );
             try {
                 $report[Resource::TYPE_API_KEY] = $this->project->listKeys($keyQueries)->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                $this->rethrowUnlessUnsupported($e);
                 $report[Resource::TYPE_API_KEY] = 0;
             }
         }
@@ -2904,7 +2911,8 @@ class Appwrite extends Source
             );
             try {
                 $report[Resource::TYPE_WEBHOOK] = $this->webhooks->list($webhookQueries)->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                $this->rethrowUnlessUnsupported($e);
                 $report[Resource::TYPE_WEBHOOK] = 0;
             }
         }

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -313,12 +313,19 @@ class Appwrite extends Source
             try {
                 $reporter();
             } catch (\Throwable $e) {
-                // Collect missing-scope (403) failures to surface together; any other error fails the report.
-                if ($e->getCode() !== Exception::CODE_FORBIDDEN) {
-                    throw $e;
+                $code = $e->getCode();
+
+                // 403 → collect to surface together; 401 → clear credential error; anything else → fail fast.
+                if ($code === Exception::CODE_FORBIDDEN) {
+                    $missingScopes[] = $group;
+                    continue;
                 }
 
-                $missingScopes[] = $group;
+                if ($code === Exception::CODE_UNAUTHORIZED) {
+                    throw new \Exception('Invalid credentials for the migration source.', $code, $e);
+                }
+
+                throw $e;
             }
         }
 

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -331,10 +331,10 @@ class Appwrite extends Source
         return $report;
     }
 
-    /** Re-throw a 403 so report() can aggregate it as a missing scope; the caller swallows other errors. */
-    private function rethrowIfForbidden(\Throwable $e): void
+    /** Re-throw credential (401) and scope (403) failures; the caller swallows other errors to zero. */
+    private function rethrowAuthErrors(\Throwable $e): void
     {
-        if ($e->getCode() === Exception::CODE_FORBIDDEN) {
+        if (\in_array($e->getCode(), [Exception::CODE_UNAUTHORIZED, Exception::CODE_FORBIDDEN], true)) {
             throw $e;
         }
     }
@@ -1678,7 +1678,7 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_RULE] = $this->proxy->listRules([Query::limit(1)])->total;
             } catch (\Throwable $e) {
-                $this->rethrowIfForbidden($e);
+                $this->rethrowAuthErrors($e);
                 $report[Resource::TYPE_RULE] = 0;
             }
         }
@@ -1695,7 +1695,7 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_PROJECT_VARIABLE] = $this->project->listVariables($variableQueries)->total;
             } catch (\Throwable $e) {
-                $this->rethrowIfForbidden($e);
+                $this->rethrowAuthErrors($e);
                 $report[Resource::TYPE_PROJECT_VARIABLE] = 0;
             }
         }
@@ -1720,7 +1720,7 @@ class Appwrite extends Source
                 // total:true returns the real count without fetching every row.
                 $report[Resource::TYPE_PROJECT_EMAIL_TEMPLATE] = $this->project->listEmailTemplates([Query::limit(1)], total: true)->total;
             } catch (\Throwable $e) {
-                $this->rethrowIfForbidden($e);
+                $this->rethrowAuthErrors($e);
                 $report[Resource::TYPE_PROJECT_EMAIL_TEMPLATE] = 0;
             }
         }
@@ -2877,7 +2877,7 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_PLATFORM] = $this->project->listPlatforms($platformQueries)->total;
             } catch (\Throwable $e) {
-                $this->rethrowIfForbidden($e);
+                $this->rethrowAuthErrors($e);
                 $report[Resource::TYPE_PLATFORM] = 0;
             }
         }
@@ -2891,7 +2891,7 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_API_KEY] = $this->project->listKeys($keyQueries)->total;
             } catch (\Throwable $e) {
-                $this->rethrowIfForbidden($e);
+                $this->rethrowAuthErrors($e);
                 $report[Resource::TYPE_API_KEY] = 0;
             }
         }
@@ -2905,7 +2905,7 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_WEBHOOK] = $this->webhooks->list($webhookQueries)->total;
             } catch (\Throwable $e) {
-                $this->rethrowIfForbidden($e);
+                $this->rethrowAuthErrors($e);
                 $report[Resource::TYPE_WEBHOOK] = 0;
             }
         }

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -317,8 +317,7 @@ class Appwrite extends Source
             } catch (\Throwable $e) {
                 $code = $e->getCode();
 
-                // 403 → collect to surface together; 401 → clear credential error; anything else → fail fast.
-                if ($code === Exception::CODE_FORBIDDEN) {
+                if ($this->isMissingScopeError($e)) {
                     $missingScopes[] = $group;
                     continue;
                 }
@@ -340,12 +339,17 @@ class Appwrite extends Source
         return $report;
     }
 
-    /** Re-throw credential (401) and scope (403) failures; the caller swallows other errors to zero. */
-    private function rethrowAuthErrors(\Throwable $e): void
+    private function isMissingScopeError(\Throwable $e): bool
     {
-        if (\in_array($e->getCode(), [Exception::CODE_UNAUTHORIZED, Exception::CODE_FORBIDDEN], true)) {
-            throw $e;
+        if (!\in_array($e->getCode(), [Exception::CODE_UNAUTHORIZED, Exception::CODE_FORBIDDEN], true)) {
+            return false;
         }
+
+        $message = $e->getMessage();
+
+        return \str_contains($message, 'general_unauthorized_scope')
+            || \str_contains($message, 'missing scopes')
+            || \str_contains($message, 'required scopes');
     }
 
     /**
@@ -1684,12 +1688,7 @@ class Appwrite extends Source
     private function reportDomains(array $resources, array &$report, array $resourceIds = []): void
     {
         if (\in_array(Resource::TYPE_RULE, $resources)) {
-            try {
-                $report[Resource::TYPE_RULE] = $this->proxy->listRules([Query::limit(1)])->total;
-            } catch (\Throwable $e) {
-                $this->rethrowAuthErrors($e);
-                $report[Resource::TYPE_RULE] = 0;
-            }
+            $report[Resource::TYPE_RULE] = $this->proxy->listRules([Query::limit(1)])->total;
         }
     }
 
@@ -1701,12 +1700,7 @@ class Appwrite extends Source
                 resourceIds: $resourceIds,
                 limit: 1
             );
-            try {
-                $report[Resource::TYPE_PROJECT_VARIABLE] = $this->project->listVariables($variableQueries)->total;
-            } catch (\Throwable $e) {
-                $this->rethrowAuthErrors($e);
-                $report[Resource::TYPE_PROJECT_VARIABLE] = 0;
-            }
+            $report[Resource::TYPE_PROJECT_VARIABLE] = $this->project->listVariables($variableQueries)->total;
         }
 
         if (\in_array(Resource::TYPE_PROJECT_PROTOCOLS, $resources)) {
@@ -1725,13 +1719,8 @@ class Appwrite extends Source
         }
 
         if (\in_array(Resource::TYPE_PROJECT_EMAIL_TEMPLATE, $resources)) {
-            try {
-                // total:true returns the real count without fetching every row.
-                $report[Resource::TYPE_PROJECT_EMAIL_TEMPLATE] = $this->project->listEmailTemplates([Query::limit(1)], total: true)->total;
-            } catch (\Throwable $e) {
-                $this->rethrowAuthErrors($e);
-                $report[Resource::TYPE_PROJECT_EMAIL_TEMPLATE] = 0;
-            }
+            // total:true returns the real count without fetching every row.
+            $report[Resource::TYPE_PROJECT_EMAIL_TEMPLATE] = $this->project->listEmailTemplates([Query::limit(1)], total: true)->total;
         }
     }
 
@@ -2883,12 +2872,7 @@ class Appwrite extends Source
                 resourceIds: $resourceIds,
                 limit: 1
             );
-            try {
-                $report[Resource::TYPE_PLATFORM] = $this->project->listPlatforms($platformQueries)->total;
-            } catch (\Throwable $e) {
-                $this->rethrowAuthErrors($e);
-                $report[Resource::TYPE_PLATFORM] = 0;
-            }
+            $report[Resource::TYPE_PLATFORM] = $this->project->listPlatforms($platformQueries)->total;
         }
 
         if (\in_array(Resource::TYPE_API_KEY, $resources)) {
@@ -2897,12 +2881,7 @@ class Appwrite extends Source
                 resourceIds: $resourceIds,
                 limit: 1
             );
-            try {
-                $report[Resource::TYPE_API_KEY] = $this->project->listKeys($keyQueries)->total;
-            } catch (\Throwable $e) {
-                $this->rethrowAuthErrors($e);
-                $report[Resource::TYPE_API_KEY] = 0;
-            }
+            $report[Resource::TYPE_API_KEY] = $this->project->listKeys($keyQueries)->total;
         }
 
         if (\in_array(Resource::TYPE_WEBHOOK, $resources)) {
@@ -2911,12 +2890,7 @@ class Appwrite extends Source
                 resourceIds: $resourceIds,
                 limit: 1
             );
-            try {
-                $report[Resource::TYPE_WEBHOOK] = $this->webhooks->list($webhookQueries)->total;
-            } catch (\Throwable $e) {
-                $this->rethrowAuthErrors($e);
-                $report[Resource::TYPE_WEBHOOK] = 0;
-            }
+            $report[Resource::TYPE_WEBHOOK] = $this->webhooks->list($webhookQueries)->total;
         }
 
         if (\in_array(Resource::TYPE_SMTP, $resources)) {


### PR DESCRIPTION
## Problem

`Appwrite::report()` wrapped every resource group in a single try/catch and rethrew on the first failure. A migration source on an older version (or with a service disabled) would 404 on one resource type, aborting discovery of **every** resource — the wizard then showed a generic "couldn't load resources" with no way to distinguish a real connectivity problem, an invalid key, or a missing scope.

## Change

- **Reachability gate first.** Probe `/health/version` (unauthenticated) before anything else, so a wrong/unreachable endpoint fails with a clear, distinct error.
- **Each resource group reported independently** via first-class callables (so `$report` is passed by reference at call time). The per-group catch routes failures by intent:
  - **403 (missing scope)** → collected across all groups and surfaced together as `Missing required scopes for: <groups>`.
  - **401 (invalid/expired key)** → fails fast with a clear credential error.
  - **anything else** (server, rate limit, connectivity) → fails fast; no partial reports.
- **Optional reporters** (integrations platforms/keys/webhooks, project variables/email templates, domain rules) keep their inner catches that default to a `0` count, but now re-throw credential (401) and scope (403) failures via `rethrowAuthErrors()` so those are never silently zeroed.

## Notes

No public API change — `report()` still returns the report array and throws on credential/connectivity failures. The behavioural change is that failures are now classified (reachable, invalid key, missing scopes, other) instead of collapsing into one opaque error.