### PR TITLE
fix: strip unknown internal attributes during migration

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -1405,9 +1405,13 @@ class Appwrite extends Destination
                 );
                 // Strip row payload fields the table doesn't declare — guards against orphans surviving in source archives.
                 if ($dbForDatabases->getAdapter()->getSupportForAttributes()) {
+                    $knownInternal = ['$id', '$permissions', '$collection', '$tenant', '$createdAt', '$updatedAt'];
                     foreach ($this->rowBuffer as $row) {
                         foreach ($row as $key => $value) {
                             if (\str_starts_with($key, '$')) {
+                                if (!\in_array($key, $knownInternal, true)) {
+                                    $row->removeAttribute($key);
+                                }
                                 continue;
                             }
 

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -1370,6 +1370,7 @@ class Appwrite extends Source
                     unset($row['$collection']);
                     unset($row['$tableId']);
                     unset($row['$table']);
+                    unset($row['$internalId']);
 
                     $row = self::getRecord($table->getDatabase()->getType(), [
                         'id' => $id,


### PR DESCRIPTION
## Description

Fixes internal attribute leakage during Appwrite-to-Appwrite migration, which causes Invalid document structure: Unknown attribute: "" errors.

## Changes

### Source (Appwrite.php)
- Added $internalId to the list of stripped internal fields when exporting records

### Destination (Appwrite.php)
- Replaced blind continue for all $-prefixed fields with an explicit allowlist ($id, $permissions, $collection, $tenant, $createdAt, $updatedAt)
- Unknown $-prefixed fields (e.g. $sequence from older sources, $databaseId, $tableId, $internalId) are now stripped before document creation, preventing Structure validator rejections

## Related Issues
- Fixes appwrite/appwrite#10265
