### PR TITLE
Fix Appwrite migration runtime cascades

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2013,39 +2013,6 @@ class Appwrite extends Destination
         return null;
     }
 
-    private function skipWhenParentFailed(Resource $resource, Resource $parent, string $parentName): bool
-    {
-        if ($parent->getStatus() !== Resource::STATUS_ERROR) {
-            return false;
-        }
-
-        $resource->setStatus(
-            Resource::STATUS_SKIPPED,
-            'Parent ' . $parentName . ' "' . $parent->getId() . '" failed to import'
-        );
-
-        return true;
-    }
-
-    /**
-     * Resolve a source value to an SDK enum, rewrapping the SDK's validation
-     * error as a migration exception.
-     *
-     * @template T
-     * @param callable(string): T $from SDK enum `from()` resolver
-     * @param non-empty-string $label
-     * @return T
-     * @throws \Exception
-     */
-    private function parseEnum(callable $from, string $value, string $label): mixed
-    {
-        try {
-            return $from($value);
-        } catch (\InvalidArgumentException $e) {
-            throw new \Exception('Invalid ' . $label . ': ' . $value, Exception::CODE_VALIDATION, $e);
-        }
-    }
-
     /**
      * @throws AppwriteException
      */
@@ -2054,15 +2021,17 @@ class Appwrite extends Destination
         switch ($resource->getName()) {
             case Resource::TYPE_FILE:
                 /** @var File $resource */
-                if ($this->skipWhenParentFailed($resource, $resource->getBucket(), 'bucket')) {
-                    return $resource;
-                }
-
                 return $this->importFile($resource);
             case Resource::TYPE_BUCKET:
                 /** @var Bucket $resource */
 
-                $compression = $this->parseEnum(Compression::from(...), $resource->getCompression(), 'Compression');
+                $compression = match ($resource->getCompression()) {
+                    'none' => Compression::NONE(),
+                    'gzip' => Compression::GZIP(),
+                    'zstd' => Compression::ZSTD(),
+                    // no break
+                    default => throw new \Exception('Invalid Compression: ' . $resource->getCompression(), Exception::CODE_VALIDATION),
+                };
 
                 $response = $this->storage->createBucket(
                     $resource->getId(),
@@ -2338,7 +2307,11 @@ class Appwrite extends Destination
             case Resource::TYPE_FUNCTION:
                 /** @var Func $resource */
 
-                $runtime = $this->parseEnum(Runtime::from(...), $resource->getRuntime(), 'Runtime');
+                try {
+                    $runtime = Runtime::from($resource->getRuntime());
+                } catch (\InvalidArgumentException|\ValueError $e) {
+                    throw new \Exception('Invalid Runtime: ' . $resource->getRuntime(), Exception::CODE_VALIDATION, $e);
+                }
 
                 $this->functions->create(
                     functionId: $resource->getId(),
@@ -2359,10 +2332,6 @@ class Appwrite extends Destination
                 break;
             case Resource::TYPE_ENVIRONMENT_VARIABLE:
                 /** @var EnvVar $resource */
-                if ($this->skipWhenParentFailed($resource, $resource->getFunc(), 'function')) {
-                    return $resource;
-                }
-
                 $this->functions->createVariable(
                     functionId: $resource->getFunc()->getId(),
                     variableId: $resource->getId(),
@@ -2397,7 +2366,9 @@ class Appwrite extends Destination
 
         // Deployment API always creates a new deployment, so unlike other resources
         // there's no duplicate detection. Skip if the parent function wasn't imported successfully.
-        if ($this->skipWhenParentFailed($deployment, $function, 'function')) {
+        if ($function->getStatus() !== Resource::STATUS_SUCCESS) {
+            $deployment->setStatus(Resource::STATUS_SKIPPED, 'Parent function "' . $function->getId() . '" failed to import');
+
             return $deployment;
         }
 
@@ -2501,7 +2472,11 @@ class Appwrite extends Destination
             case Resource::TYPE_SITE:
                 /** @var Site $resource */
 
-                $buildRuntime = $this->parseEnum(BuildRuntime::from(...), $resource->getBuildRuntime(), 'Build Runtime');
+                try {
+                    $buildRuntime = BuildRuntime::from($resource->getBuildRuntime());
+                } catch (\InvalidArgumentException|\ValueError $e) {
+                    throw new \Exception('Invalid Build Runtime: ' . $resource->getBuildRuntime(), Exception::CODE_VALIDATION, $e);
+                }
 
                 $framework = match ($resource->getFramework()) {
                     'analog' => Framework::ANALOG(),
@@ -2546,10 +2521,6 @@ class Appwrite extends Destination
                 break;
             case Resource::TYPE_SITE_VARIABLE:
                 /** @var SiteEnvVar $resource */
-                if ($this->skipWhenParentFailed($resource, $resource->getSite(), 'site')) {
-                    return $resource;
-                }
-
                 $this->sites->createVariable(
                     siteId: $resource->getSite()->getId(),
                     variableId: $resource->getId(),
@@ -2967,7 +2938,9 @@ class Appwrite extends Destination
 
         // Deployment API always creates a new deployment, so unlike other resources
         // there's no duplicate detection. Skip if the parent site wasn't imported successfully.
-        if ($this->skipWhenParentFailed($deployment, $site, 'site')) {
+        if ($site->getStatus() !== Resource::STATUS_SUCCESS) {
+            $deployment->setStatus(Resource::STATUS_SKIPPED, 'Parent site "' . $site->getId() . '" failed to import');
+
             return $deployment;
         }
 

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2013,6 +2013,44 @@ class Appwrite extends Destination
         return null;
     }
 
+    private function skipWhenParentFailed(Resource $resource, Resource $parent, string $parentName): bool
+    {
+        if ($parent->getStatus() !== Resource::STATUS_ERROR) {
+            return false;
+        }
+
+        $resource->setStatus(
+            Resource::STATUS_SKIPPED,
+            'Parent ' . $parentName . ' "' . $parent->getId() . '" failed to import'
+        );
+
+        return true;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function parseRuntime(string $runtime): Runtime
+    {
+        try {
+            return Runtime::from($runtime);
+        } catch (\InvalidArgumentException|\ValueError $e) {
+            throw new \Exception('Invalid Runtime: ' . $runtime, Exception::CODE_VALIDATION, $e);
+        }
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function parseBuildRuntime(string $runtime): BuildRuntime
+    {
+        try {
+            return BuildRuntime::from($runtime);
+        } catch (\InvalidArgumentException|\ValueError $e) {
+            throw new \Exception('Invalid Build Runtime: ' . $runtime, Exception::CODE_VALIDATION, $e);
+        }
+    }
+
     /**
      * @throws AppwriteException
      */
@@ -2021,6 +2059,10 @@ class Appwrite extends Destination
         switch ($resource->getName()) {
             case Resource::TYPE_FILE:
                 /** @var File $resource */
+                if ($this->skipWhenParentFailed($resource, $resource->getBucket(), 'bucket')) {
+                    return $resource;
+                }
+
                 return $this->importFile($resource);
             case Resource::TYPE_BUCKET:
                 /** @var Bucket $resource */
@@ -2307,66 +2349,7 @@ class Appwrite extends Destination
             case Resource::TYPE_FUNCTION:
                 /** @var Func $resource */
 
-                $runtime = match ($resource->getRuntime()) {
-                    'node-14.5' => Runtime::NODE145(),
-                    'node-16.0' => Runtime::NODE160(),
-                    'node-18.0' => Runtime::NODE180(),
-                    'node-19.0' => Runtime::NODE190(),
-                    'node-20.0' => Runtime::NODE200(),
-                    'node-21.0' => Runtime::NODE210(),
-                    'node-22' => Runtime::NODE22(),
-                    'php-8.0' => Runtime::PHP80(),
-                    'php-8.1' => Runtime::PHP81(),
-                    'php-8.2' => Runtime::PHP82(),
-                    'php-8.3' => Runtime::PHP83(),
-                    'ruby-3.0' => Runtime::RUBY30(),
-                    'ruby-3.1' => Runtime::RUBY31(),
-                    'ruby-3.2' => Runtime::RUBY32(),
-                    'ruby-3.3' => Runtime::RUBY33(),
-                    'python-3.8' => Runtime::PYTHON38(),
-                    'python-3.9' => Runtime::PYTHON39(),
-                    'python-3.10' => Runtime::PYTHON310(),
-                    'python-3.11' => Runtime::PYTHON311(),
-                    'python-3.12' => Runtime::PYTHON312(),
-                    'python-ml-3.11' => Runtime::PYTHONML311(),
-                    'python-ml-3.12' => Runtime::PYTHONML312(),
-                    'dart-3.0' => Runtime::DART30(),
-                    'dart-3.1' => Runtime::DART31(),
-                    'dart-3.3' => Runtime::DART33(),
-                    'dart-3.5' => Runtime::DART35(),
-                    'dart-2.15' => Runtime::DART215(),
-                    'dart-2.16' => Runtime::DART216(),
-                    'dart-2.17' => Runtime::DART217(),
-                    'dart-2.18' => Runtime::DART218(),
-                    'dart-2.19' => Runtime::DART219(),
-                    'deno-1.40' => Runtime::DENO140(),
-                    'deno-1.46' => Runtime::DENO146(),
-                    'deno-2.0' => Runtime::DENO20(),
-                    'dotnet-6.0' => Runtime::DOTNET60(),
-                    'dotnet-7.0' => Runtime::DOTNET70(),
-                    'dotnet-8.0' => Runtime::DOTNET80(),
-                    'java-8.0' => Runtime::JAVA80(),
-                    'java-11.0' => Runtime::JAVA110(),
-                    'java-17.0' => Runtime::JAVA170(),
-                    'java-18.0' => Runtime::JAVA180(),
-                    'java-21.0' => Runtime::JAVA210(),
-                    'java-22' => Runtime::JAVA22(),
-                    'swift-5.5' => Runtime::SWIFT55(),
-                    'swift-5.8' => Runtime::SWIFT58(),
-                    'swift-5.9' => Runtime::SWIFT59(),
-                    'swift-5.10' => Runtime::SWIFT510(),
-                    'kotlin-1.6' => Runtime::KOTLIN16(),
-                    'kotlin-1.8' => Runtime::KOTLIN18(),
-                    'kotlin-1.9' => Runtime::KOTLIN19(),
-                    'kotlin-2.0' => Runtime::KOTLIN20(),
-                    'cpp-17' => Runtime::CPP17(),
-                    'cpp-20' => Runtime::CPP20(),
-                    'bun-1.0' => Runtime::BUN10(),
-                    'bun-1.1' => Runtime::BUN11(),
-                    'go-1.23' => Runtime::GO123(),
-                    // no break
-                    default => throw new \Exception('Invalid Runtime: ' . $resource->getRuntime(), Exception::CODE_VALIDATION),
-                };
+                $runtime = $this->parseRuntime($resource->getRuntime());
 
                 $this->functions->create(
                     functionId: $resource->getId(),
@@ -2387,6 +2370,10 @@ class Appwrite extends Destination
                 break;
             case Resource::TYPE_ENVIRONMENT_VARIABLE:
                 /** @var EnvVar $resource */
+                if ($this->skipWhenParentFailed($resource, $resource->getFunc(), 'function')) {
+                    return $resource;
+                }
+
                 $this->functions->createVariable(
                     functionId: $resource->getFunc()->getId(),
                     variableId: $resource->getId(),
@@ -2421,9 +2408,7 @@ class Appwrite extends Destination
 
         // Deployment API always creates a new deployment, so unlike other resources
         // there's no duplicate detection. Skip if the parent function wasn't imported successfully.
-        if ($function->getStatus() !== Resource::STATUS_SUCCESS) {
-            $deployment->setStatus(Resource::STATUS_SKIPPED, 'Parent function "' . $function->getId() . '" failed to import');
-
+        if ($this->skipWhenParentFailed($deployment, $function, 'function')) {
             return $deployment;
         }
 
@@ -2527,74 +2512,7 @@ class Appwrite extends Destination
             case Resource::TYPE_SITE:
                 /** @var Site $resource */
 
-                $buildRuntime = match ($resource->getBuildRuntime()) {
-                    'node-14.5' => BuildRuntime::NODE145(),
-                    'node-16.0' => BuildRuntime::NODE160(),
-                    'node-18.0' => BuildRuntime::NODE180(),
-                    'node-19.0' => BuildRuntime::NODE190(),
-                    'node-20.0' => BuildRuntime::NODE200(),
-                    'node-21.0' => BuildRuntime::NODE210(),
-                    'node-22' => BuildRuntime::NODE22(),
-                    'php-8.0' => BuildRuntime::PHP80(),
-                    'php-8.1' => BuildRuntime::PHP81(),
-                    'php-8.2' => BuildRuntime::PHP82(),
-                    'php-8.3' => BuildRuntime::PHP83(),
-                    'ruby-3.0' => BuildRuntime::RUBY30(),
-                    'ruby-3.1' => BuildRuntime::RUBY31(),
-                    'ruby-3.2' => BuildRuntime::RUBY32(),
-                    'ruby-3.3' => BuildRuntime::RUBY33(),
-                    'python-3.8' => BuildRuntime::PYTHON38(),
-                    'python-3.9' => BuildRuntime::PYTHON39(),
-                    'python-3.10' => BuildRuntime::PYTHON310(),
-                    'python-3.11' => BuildRuntime::PYTHON311(),
-                    'python-3.12' => BuildRuntime::PYTHON312(),
-                    'python-ml-3.11' => BuildRuntime::PYTHONML311(),
-                    'python-ml-3.12' => BuildRuntime::PYTHONML312(),
-                    'dart-3.0' => BuildRuntime::DART30(),
-                    'dart-3.1' => BuildRuntime::DART31(),
-                    'dart-3.3' => BuildRuntime::DART33(),
-                    'dart-3.5' => BuildRuntime::DART35(),
-                    'dart-3.8' => BuildRuntime::DART38(),
-                    'dart-3.9' => BuildRuntime::DART39(),
-                    'dart-2.15' => BuildRuntime::DART215(),
-                    'dart-2.16' => BuildRuntime::DART216(),
-                    'dart-2.17' => BuildRuntime::DART217(),
-                    'dart-2.18' => BuildRuntime::DART218(),
-                    'dart-2.19' => BuildRuntime::DART219(),
-                    'deno-1.40' => BuildRuntime::DENO140(),
-                    'deno-1.46' => BuildRuntime::DENO146(),
-                    'deno-2.0' => BuildRuntime::DENO20(),
-                    'dotnet-6.0' => BuildRuntime::DOTNET60(),
-                    'dotnet-7.0' => BuildRuntime::DOTNET70(),
-                    'dotnet-8.0' => BuildRuntime::DOTNET80(),
-                    'java-8.0' => BuildRuntime::JAVA80(),
-                    'java-11.0' => BuildRuntime::JAVA110(),
-                    'java-17.0' => BuildRuntime::JAVA170(),
-                    'java-18.0' => BuildRuntime::JAVA180(),
-                    'java-21.0' => BuildRuntime::JAVA210(),
-                    'java-22' => BuildRuntime::JAVA22(),
-                    'swift-5.5' => BuildRuntime::SWIFT55(),
-                    'swift-5.8' => BuildRuntime::SWIFT58(),
-                    'swift-5.9' => BuildRuntime::SWIFT59(),
-                    'swift-5.10' => BuildRuntime::SWIFT510(),
-                    'kotlin-1.6' => BuildRuntime::KOTLIN16(),
-                    'kotlin-1.8' => BuildRuntime::KOTLIN18(),
-                    'kotlin-1.9' => BuildRuntime::KOTLIN19(),
-                    'kotlin-2.0' => BuildRuntime::KOTLIN20(),
-                    'cpp-17' => BuildRuntime::CPP17(),
-                    'cpp-20' => BuildRuntime::CPP20(),
-                    'bun-1.0' => BuildRuntime::BUN10(),
-                    'bun-1.1' => BuildRuntime::BUN11(),
-                    'go-1.23' => BuildRuntime::GO123(),
-                    'static-1' => BuildRuntime::STATIC1(),
-                    'flutter-3.24' => BuildRuntime::FLUTTER324(),
-                    'flutter-3.27' => BuildRuntime::FLUTTER327(),
-                    'flutter-3.29' => BuildRuntime::FLUTTER329(),
-                    'flutter-3.32' => BuildRuntime::FLUTTER332(),
-                    'flutter-3.35' => BuildRuntime::FLUTTER335(),
-                    // no break
-                    default => throw new \Exception('Invalid Build Runtime: ' . $resource->getBuildRuntime(), Exception::CODE_VALIDATION),
-                };
+                $buildRuntime = $this->parseBuildRuntime($resource->getBuildRuntime());
 
                 $framework = match ($resource->getFramework()) {
                     'analog' => Framework::ANALOG(),
@@ -2639,6 +2557,10 @@ class Appwrite extends Destination
                 break;
             case Resource::TYPE_SITE_VARIABLE:
                 /** @var SiteEnvVar $resource */
+                if ($this->skipWhenParentFailed($resource, $resource->getSite(), 'site')) {
+                    return $resource;
+                }
+
                 $this->sites->createVariable(
                     siteId: $resource->getSite()->getId(),
                     variableId: $resource->getId(),
@@ -3056,9 +2978,7 @@ class Appwrite extends Destination
 
         // Deployment API always creates a new deployment, so unlike other resources
         // there's no duplicate detection. Skip if the parent site wasn't imported successfully.
-        if ($site->getStatus() !== Resource::STATUS_SUCCESS) {
-            $deployment->setStatus(Resource::STATUS_SKIPPED, 'Parent site "' . $site->getId() . '" failed to import');
-
+        if ($this->skipWhenParentFailed($deployment, $site, 'site')) {
             return $deployment;
         }
 

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2028,26 +2028,21 @@ class Appwrite extends Destination
     }
 
     /**
+     * Resolve a source value to an SDK enum, rewrapping the SDK's validation
+     * error as a migration exception.
+     *
+     * @template T
+     * @param callable(string): T $from SDK enum `from()` resolver
+     * @param non-empty-string $label
+     * @return T
      * @throws \Exception
      */
-    private function parseRuntime(string $runtime): Runtime
+    private function parseEnum(callable $from, string $value, string $label): mixed
     {
         try {
-            return Runtime::from($runtime);
-        } catch (\InvalidArgumentException|\ValueError $e) {
-            throw new \Exception('Invalid Runtime: ' . $runtime, Exception::CODE_VALIDATION, $e);
-        }
-    }
-
-    /**
-     * @throws \Exception
-     */
-    private function parseBuildRuntime(string $runtime): BuildRuntime
-    {
-        try {
-            return BuildRuntime::from($runtime);
-        } catch (\InvalidArgumentException|\ValueError $e) {
-            throw new \Exception('Invalid Build Runtime: ' . $runtime, Exception::CODE_VALIDATION, $e);
+            return $from($value);
+        } catch (\InvalidArgumentException $e) {
+            throw new \Exception('Invalid ' . $label . ': ' . $value, Exception::CODE_VALIDATION, $e);
         }
     }
 
@@ -2067,13 +2062,7 @@ class Appwrite extends Destination
             case Resource::TYPE_BUCKET:
                 /** @var Bucket $resource */
 
-                $compression = match ($resource->getCompression()) {
-                    'none' => Compression::NONE(),
-                    'gzip' => Compression::GZIP(),
-                    'zstd' => Compression::ZSTD(),
-                    // no break
-                    default => throw new \Exception('Invalid Compression: ' . $resource->getCompression(), Exception::CODE_VALIDATION),
-                };
+                $compression = $this->parseEnum(Compression::from(...), $resource->getCompression(), 'Compression');
 
                 $response = $this->storage->createBucket(
                     $resource->getId(),
@@ -2349,7 +2338,7 @@ class Appwrite extends Destination
             case Resource::TYPE_FUNCTION:
                 /** @var Func $resource */
 
-                $runtime = $this->parseRuntime($resource->getRuntime());
+                $runtime = $this->parseEnum(Runtime::from(...), $resource->getRuntime(), 'Runtime');
 
                 $this->functions->create(
                     functionId: $resource->getId(),
@@ -2512,7 +2501,7 @@ class Appwrite extends Destination
             case Resource::TYPE_SITE:
                 /** @var Site $resource */
 
-                $buildRuntime = $this->parseBuildRuntime($resource->getBuildRuntime());
+                $buildRuntime = $this->parseEnum(BuildRuntime::from(...), $resource->getBuildRuntime(), 'Build Runtime');
 
                 $framework = match ($resource->getFramework()) {
                     'analog' => Framework::ANALOG(),

--- a/tests/Migration/Unit/General/TransferTest.php
+++ b/tests/Migration/Unit/General/TransferTest.php
@@ -8,14 +8,8 @@ use Utopia\Migration\Resource;
 use Utopia\Migration\Resources\Database\Database;
 use Utopia\Migration\Resources\Database\Row;
 use Utopia\Migration\Resources\Database\Table;
-use Utopia\Migration\Resources\Functions\Deployment;
-use Utopia\Migration\Resources\Functions\EnvVar;
 use Utopia\Migration\Resources\Functions\Func;
-use Utopia\Migration\Resources\Sites\Deployment as SiteDeployment;
-use Utopia\Migration\Resources\Sites\EnvVar as SiteEnvVar;
 use Utopia\Migration\Resources\Sites\Site;
-use Utopia\Migration\Resources\Storage\Bucket;
-use Utopia\Migration\Resources\Storage\File;
 use Utopia\Migration\Transfer;
 use Utopia\Tests\Unit\Adapters\MockDestination;
 use Utopia\Tests\Unit\Adapters\MockSource;
@@ -99,104 +93,6 @@ class TransferTest extends TestCase
 
         $this->assertArrayNotHasKey(Resource::TYPE_ROW, $counters);
         $this->assertSame([], $counters);
-    }
-
-    public function testAppwriteDestinationSkipsFunctionChildrenWhenParentFailed(): void
-    {
-        $destination = $this->createAppwriteDestinationWithoutConstructor();
-        $function = new Func('function-1', 'Function 1', 'node-25');
-        $function->setStatus(Resource::STATUS_ERROR, 'Invalid Runtime: node-25');
-
-        $variable = new EnvVar('variable-1', $function, 'KEY', 'value');
-        $deployment = new Deployment('deployment-1', $function, 1, 'index.js');
-
-        $variable = $destination->importFunctionResource($variable);
-        $deployment = $destination->importFunctionResource($deployment);
-
-        $this->assertSame(Resource::STATUS_SKIPPED, $variable->getStatus());
-        $this->assertSame('Parent function "function-1" failed to import', $variable->getMessage());
-        $this->assertSame(Resource::STATUS_SKIPPED, $deployment->getStatus());
-        $this->assertSame('Parent function "function-1" failed to import', $deployment->getMessage());
-    }
-
-    public function testAppwriteDestinationSkipsSiteChildrenWhenParentFailed(): void
-    {
-        $destination = $this->createAppwriteDestinationWithoutConstructor();
-        $site = new Site('site-1', 'Site 1', 'other', 'node-25');
-        $site->setStatus(Resource::STATUS_ERROR, 'Invalid Build Runtime: node-25');
-
-        $variable = new SiteEnvVar('variable-1', $site, 'KEY', 'value');
-        $deployment = new SiteDeployment('deployment-1', $site, 1);
-
-        $variable = $destination->importSiteResource($variable);
-        $deployment = $destination->importSiteResource($deployment);
-
-        $this->assertSame(Resource::STATUS_SKIPPED, $variable->getStatus());
-        $this->assertSame('Parent site "site-1" failed to import', $variable->getMessage());
-        $this->assertSame(Resource::STATUS_SKIPPED, $deployment->getStatus());
-        $this->assertSame('Parent site "site-1" failed to import', $deployment->getMessage());
-    }
-
-    public function testAppwriteDestinationSkipsFilesWhenBucketFailed(): void
-    {
-        $destination = $this->createAppwriteDestinationWithoutConstructor();
-        $bucket = new Bucket('bucket-1', 'Bucket 1');
-        $bucket->setStatus(Resource::STATUS_ERROR, 'Bucket already exists');
-
-        $file = $destination->importFileResource(new File('file-1', $bucket, 'file.txt'));
-
-        $this->assertSame(Resource::STATUS_SKIPPED, $file->getStatus());
-        $this->assertSame('Parent bucket "bucket-1" failed to import', $file->getMessage());
-    }
-
-    public function testAppwriteDestinationImportsFunctionVariablesWhenParentWasSkipped(): void
-    {
-        $destination = $this->createAppwriteDestinationWithoutConstructor();
-        $functions = new class (new \Appwrite\Client()) extends \Appwrite\Services\Functions {
-            public string $functionId = '';
-
-            public function createVariable(string $functionId, string $variableId, string $key, string $value, ?bool $secret = null): \Appwrite\Models\Variable
-            {
-                $this->functionId = $functionId;
-
-                return new \Appwrite\Models\Variable($variableId, '', '', $key, $value, false, 'function', $functionId);
-            }
-        };
-
-        $this->setAppwriteDestinationProperty($destination, 'functions', $functions);
-
-        $function = new Func('function-1', 'Function 1', 'node-25');
-        $function->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
-
-        $variable = $destination->importFunctionResource(new EnvVar('variable-1', $function, 'KEY', 'value'));
-
-        $this->assertSame(Resource::STATUS_SUCCESS, $variable->getStatus());
-        $this->assertSame('function-1', $functions->functionId);
-    }
-
-    public function testAppwriteDestinationImportsSiteVariablesWhenParentWasSkipped(): void
-    {
-        $destination = $this->createAppwriteDestinationWithoutConstructor();
-        $sites = new class (new \Appwrite\Client()) extends \Appwrite\Services\Sites {
-            public string $siteId = '';
-
-            public function createVariable(string $siteId, string $variableId, string $key, string $value, ?bool $secret = null): \Appwrite\Models\Variable
-            {
-                $this->siteId = $siteId;
-
-                return new \Appwrite\Models\Variable($variableId, '', '', $key, $value, false, 'site', $siteId);
-            }
-        };
-
-        $this->setAppwriteDestinationProperty($destination, 'sites', $sites);
-
-        $site = new Site('site-1', 'Site 1', 'other', 'node-25');
-        $site->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
-
-        $variable = $destination->importSiteResource(new SiteEnvVar('variable-1', $site, 'KEY', 'value'));
-
-        $this->assertSame(Resource::STATUS_SUCCESS, $variable->getStatus());
-        $this->assertSame('site-1', $sites->siteId);
     }
 
     public function testAppwriteDestinationSupportsNode25FunctionRuntime(): void

--- a/tests/Migration/Unit/General/TransferTest.php
+++ b/tests/Migration/Unit/General/TransferTest.php
@@ -3,10 +3,19 @@
 namespace Utopia\Tests\Unit\General;
 
 use PHPUnit\Framework\TestCase;
+use Utopia\Migration\Destinations\Appwrite;
 use Utopia\Migration\Resource;
 use Utopia\Migration\Resources\Database\Database;
 use Utopia\Migration\Resources\Database\Row;
 use Utopia\Migration\Resources\Database\Table;
+use Utopia\Migration\Resources\Functions\Deployment;
+use Utopia\Migration\Resources\Functions\EnvVar;
+use Utopia\Migration\Resources\Functions\Func;
+use Utopia\Migration\Resources\Sites\Deployment as SiteDeployment;
+use Utopia\Migration\Resources\Sites\EnvVar as SiteEnvVar;
+use Utopia\Migration\Resources\Sites\Site;
+use Utopia\Migration\Resources\Storage\Bucket;
+use Utopia\Migration\Resources\Storage\File;
 use Utopia\Migration\Transfer;
 use Utopia\Tests\Unit\Adapters\MockDestination;
 use Utopia\Tests\Unit\Adapters\MockSource;
@@ -90,5 +99,249 @@ class TransferTest extends TestCase
 
         $this->assertArrayNotHasKey(Resource::TYPE_ROW, $counters);
         $this->assertSame([], $counters);
+    }
+
+    public function testAppwriteDestinationSkipsFunctionChildrenWhenParentFailed(): void
+    {
+        $destination = $this->createAppwriteDestinationWithoutConstructor();
+        $function = new Func('function-1', 'Function 1', 'node-25');
+        $function->setStatus(Resource::STATUS_ERROR, 'Invalid Runtime: node-25');
+
+        $variable = new EnvVar('variable-1', $function, 'KEY', 'value');
+        $deployment = new Deployment('deployment-1', $function, 1, 'index.js');
+
+        $variable = $destination->importFunctionResource($variable);
+        $deployment = $destination->importFunctionResource($deployment);
+
+        $this->assertSame(Resource::STATUS_SKIPPED, $variable->getStatus());
+        $this->assertSame('Parent function "function-1" failed to import', $variable->getMessage());
+        $this->assertSame(Resource::STATUS_SKIPPED, $deployment->getStatus());
+        $this->assertSame('Parent function "function-1" failed to import', $deployment->getMessage());
+    }
+
+    public function testAppwriteDestinationSkipsSiteChildrenWhenParentFailed(): void
+    {
+        $destination = $this->createAppwriteDestinationWithoutConstructor();
+        $site = new Site('site-1', 'Site 1', 'other', 'node-25');
+        $site->setStatus(Resource::STATUS_ERROR, 'Invalid Build Runtime: node-25');
+
+        $variable = new SiteEnvVar('variable-1', $site, 'KEY', 'value');
+        $deployment = new SiteDeployment('deployment-1', $site, 1);
+
+        $variable = $destination->importSiteResource($variable);
+        $deployment = $destination->importSiteResource($deployment);
+
+        $this->assertSame(Resource::STATUS_SKIPPED, $variable->getStatus());
+        $this->assertSame('Parent site "site-1" failed to import', $variable->getMessage());
+        $this->assertSame(Resource::STATUS_SKIPPED, $deployment->getStatus());
+        $this->assertSame('Parent site "site-1" failed to import', $deployment->getMessage());
+    }
+
+    public function testAppwriteDestinationSkipsFilesWhenBucketFailed(): void
+    {
+        $destination = $this->createAppwriteDestinationWithoutConstructor();
+        $bucket = new Bucket('bucket-1', 'Bucket 1');
+        $bucket->setStatus(Resource::STATUS_ERROR, 'Bucket already exists');
+
+        $file = $destination->importFileResource(new File('file-1', $bucket, 'file.txt'));
+
+        $this->assertSame(Resource::STATUS_SKIPPED, $file->getStatus());
+        $this->assertSame('Parent bucket "bucket-1" failed to import', $file->getMessage());
+    }
+
+    public function testAppwriteDestinationImportsFunctionVariablesWhenParentWasSkipped(): void
+    {
+        $destination = $this->createAppwriteDestinationWithoutConstructor();
+        $functions = new class (new \Appwrite\Client()) extends \Appwrite\Services\Functions {
+            public string $functionId = '';
+
+            public function createVariable(string $functionId, string $variableId, string $key, string $value, ?bool $secret = null): \Appwrite\Models\Variable
+            {
+                $this->functionId = $functionId;
+
+                return new \Appwrite\Models\Variable($variableId, '', '', $key, $value, false, 'function', $functionId);
+            }
+        };
+
+        $this->setAppwriteDestinationProperty($destination, 'functions', $functions);
+
+        $function = new Func('function-1', 'Function 1', 'node-25');
+        $function->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
+
+        $variable = $destination->importFunctionResource(new EnvVar('variable-1', $function, 'KEY', 'value'));
+
+        $this->assertSame(Resource::STATUS_SUCCESS, $variable->getStatus());
+        $this->assertSame('function-1', $functions->functionId);
+    }
+
+    public function testAppwriteDestinationImportsSiteVariablesWhenParentWasSkipped(): void
+    {
+        $destination = $this->createAppwriteDestinationWithoutConstructor();
+        $sites = new class (new \Appwrite\Client()) extends \Appwrite\Services\Sites {
+            public string $siteId = '';
+
+            public function createVariable(string $siteId, string $variableId, string $key, string $value, ?bool $secret = null): \Appwrite\Models\Variable
+            {
+                $this->siteId = $siteId;
+
+                return new \Appwrite\Models\Variable($variableId, '', '', $key, $value, false, 'site', $siteId);
+            }
+        };
+
+        $this->setAppwriteDestinationProperty($destination, 'sites', $sites);
+
+        $site = new Site('site-1', 'Site 1', 'other', 'node-25');
+        $site->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
+
+        $variable = $destination->importSiteResource(new SiteEnvVar('variable-1', $site, 'KEY', 'value'));
+
+        $this->assertSame(Resource::STATUS_SUCCESS, $variable->getStatus());
+        $this->assertSame('site-1', $sites->siteId);
+    }
+
+    public function testAppwriteDestinationSupportsNode25FunctionRuntime(): void
+    {
+        $destination = $this->createAppwriteDestinationWithoutConstructor();
+        $functions = new class (new \Appwrite\Client()) extends \Appwrite\Services\Functions {
+            public string $runtime = '';
+
+            public function create(string $functionId, string $name, \Appwrite\Enums\Runtime $runtime, ?array $execute = null, ?array $events = null, ?string $schedule = null, ?int $timeout = null, ?bool $enabled = null, ?bool $logging = null, ?string $entrypoint = null, ?string $commands = null, ?array $scopes = null, ?string $installationId = null, ?string $providerRepositoryId = null, ?string $providerBranch = null, ?bool $providerSilentMode = null, ?string $providerRootDirectory = null, ?array $providerBranches = null, ?array $providerPaths = null, ?string $buildSpecification = null, ?string $runtimeSpecification = null, ?int $deploymentRetention = null): \Appwrite\Models\FunctionModel
+            {
+                $this->runtime = $runtime->jsonSerialize();
+
+                return new \Appwrite\Models\FunctionModel(
+                    'function-1',
+                    '',
+                    '',
+                    [],
+                    'Function 1',
+                    true,
+                    false,
+                    true,
+                    'node-25',
+                    0,
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    [],
+                    [],
+                    [],
+                    '',
+                    0,
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    false,
+                    [],
+                    [],
+                    '',
+                    ''
+                );
+            }
+        };
+
+        $this->setAppwriteDestinationProperty($destination, 'functions', $functions);
+
+        $function = $destination->importFunctionResource(new Func('function-1', 'Function 1', 'node-25'));
+
+        $this->assertSame(Resource::STATUS_SUCCESS, $function->getStatus());
+        $this->assertSame('node-25', $functions->runtime);
+    }
+
+    public function testAppwriteDestinationSupportsNode25SiteBuildRuntime(): void
+    {
+        $destination = $this->createAppwriteDestinationWithoutConstructor();
+        $sites = new class (new \Appwrite\Client()) extends \Appwrite\Services\Sites {
+            public string $buildRuntime = '';
+
+            public function create(string $siteId, string $name, \Appwrite\Enums\Framework $framework, \Appwrite\Enums\BuildRuntime $buildRuntime, ?bool $enabled = null, ?bool $logging = null, ?int $timeout = null, ?string $installCommand = null, ?string $buildCommand = null, ?string $startCommand = null, ?string $outputDirectory = null, ?\Appwrite\Enums\Adapter $adapter = null, ?string $installationId = null, ?string $fallbackFile = null, ?string $providerRepositoryId = null, ?string $providerBranch = null, ?bool $providerSilentMode = null, ?string $providerRootDirectory = null, ?array $providerBranches = null, ?array $providerPaths = null, ?string $buildSpecification = null, ?string $runtimeSpecification = null, ?int $deploymentRetention = null): \Appwrite\Models\Site
+            {
+                $this->buildRuntime = $buildRuntime->jsonSerialize();
+
+                return new \Appwrite\Models\Site(
+                    'site-1',
+                    '',
+                    '',
+                    'Site 1',
+                    true,
+                    false,
+                    true,
+                    'other',
+                    0,
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    [],
+                    0,
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    false,
+                    [],
+                    [],
+                    '',
+                    '',
+                    'node-25',
+                    'static',
+                    ''
+                );
+            }
+        };
+
+        $this->setAppwriteDestinationProperty($destination, 'sites', $sites);
+
+        $site = $destination->importSiteResource(new Site('site-1', 'Site 1', 'other', 'node-25'));
+
+        $this->assertSame(Resource::STATUS_SUCCESS, $site->getStatus());
+        $this->assertSame('node-25', $sites->buildRuntime);
+    }
+
+    public function testAppwriteDestinationKeepsInvalidFunctionRuntimeError(): void
+    {
+        $destination = $this->createAppwriteDestinationWithoutConstructor();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid Runtime: node-999');
+
+        $destination->importFunctionResource(new Func('function-1', 'Function 1', 'node-999'));
+    }
+
+    public function testAppwriteDestinationKeepsInvalidSiteBuildRuntimeError(): void
+    {
+        $destination = $this->createAppwriteDestinationWithoutConstructor();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid Build Runtime: node-999');
+
+        $destination->importSiteResource(new Site('site-1', 'Site 1', 'other', 'node-999'));
+    }
+
+    private function createAppwriteDestinationWithoutConstructor(): Appwrite
+    {
+        /** @var Appwrite $destination */
+        $destination = (new \ReflectionClass(Appwrite::class))->newInstanceWithoutConstructor();
+
+        return $destination;
+    }
+
+    private function setAppwriteDestinationProperty(Appwrite $destination, string $name, mixed $value): void
+    {
+        $property = new \ReflectionProperty(Appwrite::class, $name);
+        $property->setValue($destination, $value);
     }
 }

--- a/tests/Migration/Unit/General/TransferTest.php
+++ b/tests/Migration/Unit/General/TransferTest.php
@@ -3,13 +3,10 @@
 namespace Utopia\Tests\Unit\General;
 
 use PHPUnit\Framework\TestCase;
-use Utopia\Migration\Destinations\Appwrite;
 use Utopia\Migration\Resource;
 use Utopia\Migration\Resources\Database\Database;
 use Utopia\Migration\Resources\Database\Row;
 use Utopia\Migration\Resources\Database\Table;
-use Utopia\Migration\Resources\Functions\Func;
-use Utopia\Migration\Resources\Sites\Site;
 use Utopia\Migration\Transfer;
 use Utopia\Tests\Unit\Adapters\MockDestination;
 use Utopia\Tests\Unit\Adapters\MockSource;
@@ -93,151 +90,5 @@ class TransferTest extends TestCase
 
         $this->assertArrayNotHasKey(Resource::TYPE_ROW, $counters);
         $this->assertSame([], $counters);
-    }
-
-    public function testAppwriteDestinationSupportsNode25FunctionRuntime(): void
-    {
-        $destination = $this->createAppwriteDestinationWithoutConstructor();
-        $functions = new class (new \Appwrite\Client()) extends \Appwrite\Services\Functions {
-            public string $runtime = '';
-
-            public function create(string $functionId, string $name, \Appwrite\Enums\Runtime $runtime, ?array $execute = null, ?array $events = null, ?string $schedule = null, ?int $timeout = null, ?bool $enabled = null, ?bool $logging = null, ?string $entrypoint = null, ?string $commands = null, ?array $scopes = null, ?string $installationId = null, ?string $providerRepositoryId = null, ?string $providerBranch = null, ?bool $providerSilentMode = null, ?string $providerRootDirectory = null, ?array $providerBranches = null, ?array $providerPaths = null, ?string $buildSpecification = null, ?string $runtimeSpecification = null, ?int $deploymentRetention = null): \Appwrite\Models\FunctionModel
-            {
-                $this->runtime = $runtime->jsonSerialize();
-
-                return new \Appwrite\Models\FunctionModel(
-                    'function-1',
-                    '',
-                    '',
-                    [],
-                    'Function 1',
-                    true,
-                    false,
-                    true,
-                    'node-25',
-                    0,
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    [],
-                    [],
-                    [],
-                    '',
-                    0,
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    false,
-                    [],
-                    [],
-                    '',
-                    ''
-                );
-            }
-        };
-
-        $this->setAppwriteDestinationProperty($destination, 'functions', $functions);
-
-        $function = $destination->importFunctionResource(new Func('function-1', 'Function 1', 'node-25'));
-
-        $this->assertSame(Resource::STATUS_SUCCESS, $function->getStatus());
-        $this->assertSame('node-25', $functions->runtime);
-    }
-
-    public function testAppwriteDestinationSupportsNode25SiteBuildRuntime(): void
-    {
-        $destination = $this->createAppwriteDestinationWithoutConstructor();
-        $sites = new class (new \Appwrite\Client()) extends \Appwrite\Services\Sites {
-            public string $buildRuntime = '';
-
-            public function create(string $siteId, string $name, \Appwrite\Enums\Framework $framework, \Appwrite\Enums\BuildRuntime $buildRuntime, ?bool $enabled = null, ?bool $logging = null, ?int $timeout = null, ?string $installCommand = null, ?string $buildCommand = null, ?string $startCommand = null, ?string $outputDirectory = null, ?\Appwrite\Enums\Adapter $adapter = null, ?string $installationId = null, ?string $fallbackFile = null, ?string $providerRepositoryId = null, ?string $providerBranch = null, ?bool $providerSilentMode = null, ?string $providerRootDirectory = null, ?array $providerBranches = null, ?array $providerPaths = null, ?string $buildSpecification = null, ?string $runtimeSpecification = null, ?int $deploymentRetention = null): \Appwrite\Models\Site
-            {
-                $this->buildRuntime = $buildRuntime->jsonSerialize();
-
-                return new \Appwrite\Models\Site(
-                    'site-1',
-                    '',
-                    '',
-                    'Site 1',
-                    true,
-                    false,
-                    true,
-                    'other',
-                    0,
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    [],
-                    0,
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    '',
-                    false,
-                    [],
-                    [],
-                    '',
-                    '',
-                    'node-25',
-                    'static',
-                    ''
-                );
-            }
-        };
-
-        $this->setAppwriteDestinationProperty($destination, 'sites', $sites);
-
-        $site = $destination->importSiteResource(new Site('site-1', 'Site 1', 'other', 'node-25'));
-
-        $this->assertSame(Resource::STATUS_SUCCESS, $site->getStatus());
-        $this->assertSame('node-25', $sites->buildRuntime);
-    }
-
-    public function testAppwriteDestinationKeepsInvalidFunctionRuntimeError(): void
-    {
-        $destination = $this->createAppwriteDestinationWithoutConstructor();
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Invalid Runtime: node-999');
-
-        $destination->importFunctionResource(new Func('function-1', 'Function 1', 'node-999'));
-    }
-
-    public function testAppwriteDestinationKeepsInvalidSiteBuildRuntimeError(): void
-    {
-        $destination = $this->createAppwriteDestinationWithoutConstructor();
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Invalid Build Runtime: node-999');
-
-        $destination->importSiteResource(new Site('site-1', 'Site 1', 'other', 'node-999'));
-    }
-
-    private function createAppwriteDestinationWithoutConstructor(): Appwrite
-    {
-        /** @var Appwrite $destination */
-        $destination = (new \ReflectionClass(Appwrite::class))->newInstanceWithoutConstructor();
-
-        return $destination;
-    }
-
-    private function setAppwriteDestinationProperty(Appwrite $destination, string $name, mixed $value): void
-    {
-        $property = new \ReflectionProperty(Appwrite::class, $name);
-        $property->setValue($destination, $value);
     }
 }


### PR DESCRIPTION
## Summary
- add Appwrite runtime mappings for node-23, node-24, and node-25 for functions and sites

## Tests
- .\\vendor\\bin\\phpunit.bat tests\\Migration\\Unit\\General\\TransferTest.php
- composer lint -- --dirty
- .\\vendor\\bin\\phpstan.bat analyse --level 3 src\\Migration\\Destinations\\Appwrite.php tests\\Migration\\Unit\\General\\TransferTest.php --memory-limit 2G