### PR TITLE
Support duplicate handling for Appwrite imports

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -165,14 +165,7 @@ class Appwrite extends Destination
      */
     private array $processedTwoWayPairs = [];
 
-    /**
-     * Chunked uploads (currently: files) call their import method once per
-     * chunk on the same resource object — the skip/overwrite decision is only
-     * evaluated on the first chunk, and this records a "skip" verdict so later
-     * chunks of the same upload don't re-upload. Keyed by "{type}:{id}".
-     *
-     * @var array<string, true>
-     */
+    /** @var array<string, true> Skip verdicts for later chunks of the same upload. */
     private array $skippedChunkedUploads = [];
 
     /**
@@ -2025,22 +2018,6 @@ class Appwrite extends Destination
         return null;
     }
 
-    /**
-     * Skip/overwrite gate for re-migration — a Template Method around the
-     * existing `OnDuplicate::resolveSchemaAction` decision.
-     *
-     * `fail` (the default) always returns false immediately, without even
-     * looking at $exists. That means every caller's normal create path
-     * — whatever it does today — runs completely untouched. This function
-     * only ever changes behavior when the mode is `skip` or `overwrite`.
-     *
-     * @param callable(): void $overwrite update-in-place, or delete + recreate
-     * @return bool true when this call fully handled the resource (it was
-     *              skipped, or $overwrite ran) — the caller must not run its
-     *              own create logic. False — the caller should proceed with
-     *              its existing create path (covers both "fail" and
-     *              "doesn't exist on destination yet").
-     */
     protected function resolveDuplicate(
         Resource $resource,
         bool $exists,
@@ -2064,16 +2041,6 @@ class Appwrite extends Destination
         }
     }
 
-    /**
-     * Existence check for SDK-backed resources. Returns the fetched model, or
-     * null when the SDK reports 404 ("not found"); any other AppwriteException
-     * re-throws — a scope/network/server error must surface as a failure, not
-     * be silently treated as "doesn't exist yet".
-     *
-     * @template T
-     * @param callable(): T $get
-     * @return T|null
-     */
     protected function sdkGetOrNull(callable $get): mixed
     {
         try {
@@ -2174,12 +2141,6 @@ class Appwrite extends Destination
         $bucketId = $file->getBucket()->getId();
         $fileId = $file->getId();
 
-        // Chunked uploads call importFile() once per chunk (same File object,
-        // start/end advancing each time) — the duplicate decision only makes
-        // sense once, on the first chunk. Later chunks of a file skipped on
-        // chunk 0 must also be skipped, since the framework resets status to
-        // PROCESSING before every call. `fail` never reaches this block, so
-        // its upload path (and the 5xx/small-file split below) is untouched.
         if ($this->onDuplicate !== OnDuplicate::Fail) {
             if ($file->getStart() === 0) {
                 $existingFile = $this->sdkGetOrNull(fn () => $this->storage->getFile($bucketId, $fileId));
@@ -2330,10 +2291,7 @@ class Appwrite extends Destination
                 $user = $resource->getUser();
 
                 if ($this->onDuplicate !== OnDuplicate::Fail) {
-                    // createMembership() doesn't accept a caller-supplied ID —
-                    // the destination always mints its own, so it never
-                    // matches the source membership ID. Look up the existing
-                    // membership by (team, user) instead.
+                    // Membership IDs are destination-generated; match by team/user.
                     $existingMemberships = $this->teams->listMemberships($teamId, [
                         SdkQuery::equal('userId', [$user->getId()]),
                     ]);
@@ -2380,11 +2338,6 @@ class Appwrite extends Destination
         return $resource;
     }
 
-    /**
-     * Applies every User field that isn't set at creation time. Shared by the
-     * create path (runs right after `users->create`/`importPasswordUser`,
-     * same as before this method existed) and the overwrite path.
-     */
     private function applyUserState(User $resource): void
     {
         if (!empty($resource->getUsername())) {
@@ -2420,7 +2373,6 @@ class Appwrite extends Destination
         }
     }
 
-    /** Shared by the create and overwrite paths, same reasoning as applyUserState(). */
     private function applyTeamState(Team $resource): void
     {
         if (!empty($resource->getPreferences())) {
@@ -2633,12 +2585,6 @@ class Appwrite extends Destination
     {
         $function = $deployment->getFunction();
 
-        // The parent function must exist on the destination for its deployments
-        // to attach. SUCCESS = just created/overwritten; SKIPPED = already
-        // existed (Skip mode, or Overwrite with nothing newer) — in both cases
-        // it's present, so proceed and let the per-deployment duplicate check
-        // create whatever is missing. Any other status means it genuinely
-        // isn't there.
         if (!\in_array($function->getStatus(), [Resource::STATUS_SUCCESS, Resource::STATUS_SKIPPED], true)) {
             $deployment->setStatus(Resource::STATUS_SKIPPED, 'Parent function "' . $function->getId() . '" failed to import');
 
@@ -2708,24 +2654,10 @@ class Appwrite extends Destination
         return $deployment;
     }
 
-    /**
-     * Skip/overwrite path for deployments — a deliberately separate path from
-     * importDeployment()'s `fail` upload logic above, not a shared one.
-     *
-     * The deployment endpoint only honors a caller-supplied ID (`x-appwrite-id`)
-     * on the chunked/content-range request shape, which importDeployment()'s
-     * small-file branch never sends — so under `fail` the destination ID is
-     * always random and no existence check is possible. Forcing that header
-     * unconditionally here (even for a single-chunk upload covering the whole
-     * file) makes the destination ID deterministic, which is what lets the
-     * existence check below work at all.
-     */
     private function importDeploymentWithDuplicateCheck(Deployment $deployment, string $functionId): Resource
     {
         $deploymentId = $deployment->getId();
 
-        // The duplicate decision only runs once, on the first chunk — see
-        // importFile() for why chunked uploads need this guard.
         if ($deployment->getStart() === 0) {
             $existingDeployment = $this->sdkGetOrNull(
                 fn () => $this->functions->getDeployment($functionId, $deploymentId)
@@ -2957,9 +2889,6 @@ class Appwrite extends Destination
                     // Auto-created by the server when a user is created with an email/phone
                     break;
                 case 'push':
-                    // Overwriting a User already carrying this target: target IDs
-                    // aren't otherwise reconciled, so treat an existing one as
-                    // already up to date rather than erroring on re-migration.
                     if (!$this->dbForProject->getDocument('targets', $target['$id'])->isEmpty()) {
                         break;
                     }
@@ -3263,10 +3192,6 @@ class Appwrite extends Destination
         };
     }
 
-    /**
-     * Resolve providerInternalId for push targets that were written during
-     * GROUP_AUTH before the provider existed on the destination.
-     */
     private function reconcileProviderTargets(string $id): void
     {
         $provider = $this->dbForProject->getDocument('providers', $id);
@@ -3329,9 +3254,6 @@ class Appwrite extends Destination
         if ($this->onDuplicate !== OnDuplicate::Fail) {
             $existing = $this->dbForProject->getDocument('subscribers', $resource->getId());
 
-            // No SDK update exists for a subscriber — overwrite deletes (via
-            // the SDK, so the topic's total is decremented for us) and
-            // recreates through the same logic as create.
             if ($this->resolveDuplicate(
                 $resource,
                 !$existing->isEmpty(),
@@ -3418,10 +3340,6 @@ class Appwrite extends Destination
         if ($this->onDuplicate !== OnDuplicate::Fail) {
             $existing = $this->dbForProject->getDocument('messages', $resource->getId());
 
-            // The SDK's update* methods only work while a message is still a
-            // draft — a sent/scheduled message can't be updated, so overwrite
-            // deletes (cancelling any scheduled send) and recreates through
-            // the same logic as create.
             if ($this->resolveDuplicate(
                 $resource,
                 !$existing->isEmpty(),
@@ -3438,10 +3356,6 @@ class Appwrite extends Destination
         $this->createMessageOnDestination($resource);
     }
 
-    /**
-     * @throws AppwriteException
-     * @throws \Exception
-     */
     private function createMessageOnDestination(Message $resource): void
     {
         $resolvedTargets = $resource->getTargets();
@@ -3565,11 +3479,6 @@ class Appwrite extends Destination
     {
         $site = $deployment->getSite();
 
-        // The parent site must exist on the destination for its deployments to
-        // attach. SUCCESS = just created/overwritten; SKIPPED = already existed
-        // (Skip mode, or Overwrite with nothing newer) — in both cases it's
-        // present, so proceed and let the per-deployment duplicate check create
-        // whatever is missing. Any other status means it genuinely isn't there.
         if (!\in_array($site->getStatus(), [Resource::STATUS_SUCCESS, Resource::STATUS_SKIPPED], true)) {
             $deployment->setStatus(Resource::STATUS_SKIPPED, 'Parent site "' . $site->getId() . '" failed to import');
 
@@ -3639,7 +3548,6 @@ class Appwrite extends Destination
         return $deployment;
     }
 
-    /** Skip/overwrite path for site deployments — mirrors importDeploymentWithDuplicateCheck(), see that docblock. */
     private function importSiteDeploymentWithDuplicateCheck(SiteDeployment $deployment, string $siteId): Resource
     {
         $deploymentId = $deployment->getId();
@@ -3964,9 +3872,7 @@ class Appwrite extends Destination
         }
 
         if ($this->onDuplicate !== OnDuplicate::Fail) {
-            // The create endpoints don't accept a caller-supplied rule ID —
-            // the destination always assigns its own, so it never matches the
-            // source rule ID. Look up the existing rule by domain instead.
+            // Rule IDs are destination-generated; match manual rules by domain.
             $existingRules = $this->proxy->listRules([
                 SdkQuery::equal('domain', [$resource->getDomain()]),
             ]);
@@ -3978,7 +3884,6 @@ class Appwrite extends Destination
                 $resource,
                 $existingRule !== null,
                 $existingRule?->updatedAt,
-                // Rules have no update endpoint — overwrite deletes and recreates.
                 overwrite: function () use ($resource, $existingRule, &$overwriteSucceeded): void {
                     $this->proxy->deleteRule($existingRule->id);
                     $overwriteSucceeded = $this->createRuleOnDestination($resource);

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2018,7 +2018,7 @@ class Appwrite extends Destination
         return null;
     }
 
-    protected function resolveDuplicate(
+    protected function handleDuplicate(
         Resource $resource,
         bool $exists,
         ?string $destUpdatedAt,
@@ -2041,7 +2041,7 @@ class Appwrite extends Destination
         }
     }
 
-    protected function sdkGetOrNull(callable $get): mixed
+    protected function getSdkResourceOrNull(callable $get): mixed
     {
         try {
             return $get();
@@ -2051,14 +2051,6 @@ class Appwrite extends Destination
             }
             throw $e;
         }
-    }
-
-    private function skipReplaceOnlyOverwrite(Resource $resource, string $type): void
-    {
-        $resource->setStatus(
-            Resource::STATUS_SKIPPED,
-            "Already exists on destination; {$type} overwrite requires delete-before-upload"
-        );
     }
 
     /**
@@ -2082,9 +2074,9 @@ class Appwrite extends Destination
                 };
 
                 if ($this->onDuplicate !== OnDuplicate::Fail) {
-                    $existingBucket = $this->sdkGetOrNull(fn () => $this->storage->getBucket($resource->getId()));
+                    $existingBucket = $this->getSdkResourceOrNull(fn () => $this->storage->getBucket($resource->getId()));
 
-                    if ($this->resolveDuplicate(
+                    if ($this->handleDuplicate(
                         $resource,
                         $existingBucket !== null,
                         $existingBucket?->updatedAt,
@@ -2143,13 +2135,13 @@ class Appwrite extends Destination
 
         if ($this->onDuplicate !== OnDuplicate::Fail) {
             if ($file->getStart() === 0) {
-                $existingFile = $this->sdkGetOrNull(fn () => $this->storage->getFile($bucketId, $fileId));
+                $existingFile = $this->getSdkResourceOrNull(fn () => $this->storage->getFile($bucketId, $fileId));
 
-                $handled = $this->resolveDuplicate(
+                $handled = $this->handleDuplicate(
                     $file,
                     $existingFile !== null,
                     $existingFile?->updatedAt,
-                    overwrite: fn () => $this->skipReplaceOnlyOverwrite($file, 'file'),
+                    overwrite: fn () => $this->storage->deleteFile($bucketId, $fileId),
                 );
 
                 if ($handled && $file->getStatus() === Resource::STATUS_SKIPPED) {
@@ -2229,9 +2221,9 @@ class Appwrite extends Destination
             case Resource::TYPE_USER:
                 /** @var User $resource */
                 if ($this->onDuplicate !== OnDuplicate::Fail) {
-                    $existingUser = $this->sdkGetOrNull(fn () => $this->users->get($resource->getId()));
+                    $existingUser = $this->getSdkResourceOrNull(fn () => $this->users->get($resource->getId()));
 
-                    if ($this->resolveDuplicate(
+                    if ($this->handleDuplicate(
                         $resource,
                         $existingUser !== null,
                         $existingUser?->updatedAt,
@@ -2267,9 +2259,9 @@ class Appwrite extends Destination
             case Resource::TYPE_TEAM:
                 /** @var Team $resource */
                 if ($this->onDuplicate !== OnDuplicate::Fail) {
-                    $existingTeam = $this->sdkGetOrNull(fn () => $this->teams->get($resource->getId()));
+                    $existingTeam = $this->getSdkResourceOrNull(fn () => $this->teams->get($resource->getId()));
 
-                    if ($this->resolveDuplicate(
+                    if ($this->handleDuplicate(
                         $resource,
                         $existingTeam !== null,
                         $existingTeam?->updatedAt,
@@ -2297,7 +2289,7 @@ class Appwrite extends Destination
                     ]);
                     $existingMembership = $existingMemberships->memberships[0] ?? null;
 
-                    if ($this->resolveDuplicate(
+                    if ($this->handleDuplicate(
                         $resource,
                         $existingMembership !== null,
                         $existingMembership?->updatedAt,
@@ -2483,9 +2475,9 @@ class Appwrite extends Destination
                 }
 
                 if ($this->onDuplicate !== OnDuplicate::Fail) {
-                    $existingFunction = $this->sdkGetOrNull(fn () => $this->functions->get($resource->getId()));
+                    $existingFunction = $this->getSdkResourceOrNull(fn () => $this->functions->get($resource->getId()));
 
-                    if ($this->resolveDuplicate(
+                    if ($this->handleDuplicate(
                         $resource,
                         $existingFunction !== null,
                         $existingFunction?->updatedAt,
@@ -2532,11 +2524,11 @@ class Appwrite extends Destination
                 $functionId = $resource->getFunc()->getId();
 
                 if ($this->onDuplicate !== OnDuplicate::Fail) {
-                    $existingVariable = $this->sdkGetOrNull(
+                    $existingVariable = $this->getSdkResourceOrNull(
                         fn () => $this->functions->getVariable($functionId, $resource->getId())
                     );
 
-                    if ($this->resolveDuplicate(
+                    if ($this->handleDuplicate(
                         $resource,
                         $existingVariable !== null,
                         $existingVariable?->updatedAt,
@@ -2659,15 +2651,18 @@ class Appwrite extends Destination
         $deploymentId = $deployment->getId();
 
         if ($deployment->getStart() === 0) {
-            $existingDeployment = $this->sdkGetOrNull(
+            $existingDeployment = $this->getSdkResourceOrNull(
                 fn () => $this->functions->getDeployment($functionId, $deploymentId)
             );
 
-            $handled = $this->resolveDuplicate(
+            $handled = $this->handleDuplicate(
                 $deployment,
                 $existingDeployment !== null,
                 $existingDeployment?->updatedAt,
-                overwrite: fn () => $this->skipReplaceOnlyOverwrite($deployment, 'deployment'),
+                overwrite: fn () => $deployment->setStatus(
+                    Resource::STATUS_SKIPPED,
+                    'Already exists on destination; deployment overwrite requires delete-before-upload'
+                ),
             );
 
             if ($handled && $deployment->getStatus() === Resource::STATUS_SKIPPED) {
@@ -2785,9 +2780,9 @@ class Appwrite extends Destination
                 };
 
                 if ($this->onDuplicate !== OnDuplicate::Fail) {
-                    $existingSite = $this->sdkGetOrNull(fn () => $this->sites->get($resource->getId()));
+                    $existingSite = $this->getSdkResourceOrNull(fn () => $this->sites->get($resource->getId()));
 
-                    if ($this->resolveDuplicate(
+                    if ($this->handleDuplicate(
                         $resource,
                         $existingSite !== null,
                         $existingSite?->updatedAt,
@@ -2834,11 +2829,11 @@ class Appwrite extends Destination
                 $siteId = $resource->getSite()->getId();
 
                 if ($this->onDuplicate !== OnDuplicate::Fail) {
-                    $existingSiteVariable = $this->sdkGetOrNull(
+                    $existingSiteVariable = $this->getSdkResourceOrNull(
                         fn () => $this->sites->getVariable($siteId, $resource->getId())
                     );
 
-                    if ($this->resolveDuplicate(
+                    if ($this->handleDuplicate(
                         $resource,
                         $existingSiteVariable !== null,
                         $existingSiteVariable?->updatedAt,
@@ -2933,9 +2928,9 @@ class Appwrite extends Destination
         $id = $resource->getId();
 
         if ($this->onDuplicate !== OnDuplicate::Fail) {
-            $existingProvider = $this->sdkGetOrNull(fn () => $this->messaging->getProvider($id));
+            $existingProvider = $this->getSdkResourceOrNull(fn () => $this->messaging->getProvider($id));
 
-            if ($this->resolveDuplicate(
+            if ($this->handleDuplicate(
                 $resource,
                 $existingProvider !== null,
                 $existingProvider?->updatedAt,
@@ -3221,9 +3216,9 @@ class Appwrite extends Destination
         $id = $resource->getId();
 
         if ($this->onDuplicate !== OnDuplicate::Fail) {
-            $existingTopic = $this->sdkGetOrNull(fn () => $this->messaging->getTopic($id));
+            $existingTopic = $this->getSdkResourceOrNull(fn () => $this->messaging->getTopic($id));
 
-            if ($this->resolveDuplicate(
+            if ($this->handleDuplicate(
                 $resource,
                 $existingTopic !== null,
                 $existingTopic?->updatedAt,
@@ -3254,7 +3249,7 @@ class Appwrite extends Destination
         if ($this->onDuplicate !== OnDuplicate::Fail) {
             $existing = $this->dbForProject->getDocument('subscribers', $resource->getId());
 
-            if ($this->resolveDuplicate(
+            if ($this->handleDuplicate(
                 $resource,
                 !$existing->isEmpty(),
                 $existing->getUpdatedAt(),
@@ -3340,7 +3335,7 @@ class Appwrite extends Destination
         if ($this->onDuplicate !== OnDuplicate::Fail) {
             $existing = $this->dbForProject->getDocument('messages', $resource->getId());
 
-            if ($this->resolveDuplicate(
+            if ($this->handleDuplicate(
                 $resource,
                 !$existing->isEmpty(),
                 $existing->getUpdatedAt(),
@@ -3553,15 +3548,18 @@ class Appwrite extends Destination
         $deploymentId = $deployment->getId();
 
         if ($deployment->getStart() === 0) {
-            $existingDeployment = $this->sdkGetOrNull(
+            $existingDeployment = $this->getSdkResourceOrNull(
                 fn () => $this->sites->getDeployment($siteId, $deploymentId)
             );
 
-            $handled = $this->resolveDuplicate(
+            $handled = $this->handleDuplicate(
                 $deployment,
                 $existingDeployment !== null,
                 $existingDeployment?->updatedAt,
-                overwrite: fn () => $this->skipReplaceOnlyOverwrite($deployment, 'deployment'),
+                overwrite: fn () => $deployment->setStatus(
+                    Resource::STATUS_SKIPPED,
+                    'Already exists on destination; deployment overwrite requires delete-before-upload'
+                ),
             );
 
             if ($handled && $deployment->getStatus() === Resource::STATUS_SKIPPED) {
@@ -3695,7 +3693,7 @@ class Appwrite extends Destination
         $existingDoc = ($existing !== false && !$existing->isEmpty()) ? $existing : null;
 
         if ($this->onDuplicate !== OnDuplicate::Fail) {
-            if ($this->resolveDuplicate(
+            if ($this->handleDuplicate(
                 $resource,
                 $existingDoc !== null,
                 $existingDoc?->getUpdatedAt(),
@@ -3880,7 +3878,7 @@ class Appwrite extends Destination
 
             $overwriteSucceeded = false;
 
-            $handled = $this->resolveDuplicate(
+            $handled = $this->handleDuplicate(
                 $resource,
                 $existingRule !== null,
                 $existingRule?->updatedAt,
@@ -3979,7 +3977,7 @@ class Appwrite extends Destination
         $existingDoc = ($existing !== false && !$existing->isEmpty()) ? $existing : null;
 
         if ($this->onDuplicate !== OnDuplicate::Fail) {
-            if ($this->resolveDuplicate(
+            if ($this->handleDuplicate(
                 $resource,
                 $existingDoc !== null,
                 $existingDoc?->getUpdatedAt(),
@@ -4049,7 +4047,7 @@ class Appwrite extends Destination
         $existingDoc = ($existing !== false && !$existing->isEmpty()) ? $existing : null;
 
         if ($this->onDuplicate !== OnDuplicate::Fail) {
-            if ($this->resolveDuplicate(
+            if ($this->handleDuplicate(
                 $resource,
                 $existingDoc !== null,
                 $existingDoc?->getUpdatedAt(),
@@ -4228,7 +4226,7 @@ class Appwrite extends Destination
             // Secret is intentionally not regenerated on overwrite — it's only
             // ever set at creation, since rotating it would break whatever
             // already uses it.
-            if ($this->resolveDuplicate(
+            if ($this->handleDuplicate(
                 $resource,
                 $existingDoc !== null,
                 $existingDoc?->getUpdatedAt(),

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2141,7 +2141,10 @@ class Appwrite extends Destination
                     $file,
                     $existingFile !== null,
                     $existingFile?->updatedAt,
-                    overwrite: fn () => $this->storage->deleteFile($bucketId, $fileId),
+                    overwrite: fn () => $file->setStatus(
+                        Resource::STATUS_SKIPPED,
+                        'Already exists on destination; file overwrite requires delete-before-upload'
+                    ),
                 );
 
                 if ($handled && $file->getStatus() === Resource::STATUS_SKIPPED) {

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2747,7 +2747,7 @@ class Appwrite extends Destination
                 [
                     'functionId' => $functionId,
                     'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                    'activate' => 'false',
+                    'activate' => $deployment->getActivated() ? 'true' : 'false',
                     'entrypoint' => $deployment->getEntrypoint(),
                 ]
             );
@@ -2769,7 +2769,7 @@ class Appwrite extends Destination
             [
                 'functionId' => $functionId,
                 'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                'activate' => 'false',
+                'activate' => $deployment->getActivated() ? 'true' : 'false',
                 'entrypoint' => $deployment->getEntrypoint(),
             ]
         );
@@ -2834,7 +2834,7 @@ class Appwrite extends Destination
             [
                 'functionId' => $functionId,
                 'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                'activate' => 'false',
+                'activate' => $deployment->getActivated() ? 'true' : 'false',
                 'entrypoint' => $deployment->getEntrypoint(),
             ]
         );
@@ -3643,7 +3643,7 @@ class Appwrite extends Destination
                 [
                     'siteId' => $siteId,
                     'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                    'activate' => 'false',
+                    'activate' => $deployment->getActivated() ? 'true' : 'false',
                 ]
             );
 
@@ -3668,7 +3668,7 @@ class Appwrite extends Destination
             [
                 'siteId' => $siteId,
                 'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                'activate' => 'false',
+                'activate' => $deployment->getActivated() ? 'true' : 'false',
             ]
         );
 
@@ -3732,7 +3732,7 @@ class Appwrite extends Destination
             [
                 'siteId' => $siteId,
                 'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                'activate' => 'false',
+                'activate' => $deployment->getActivated() ? 'true' : 'false',
             ]
         );
 

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2747,7 +2747,7 @@ class Appwrite extends Destination
                 [
                     'functionId' => $functionId,
                     'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                    'activate' => $deployment->getActivated() ? 'true' : 'false',
+                    'activate' => 'false',
                     'entrypoint' => $deployment->getEntrypoint(),
                 ]
             );
@@ -2769,7 +2769,7 @@ class Appwrite extends Destination
             [
                 'functionId' => $functionId,
                 'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                'activate' => $deployment->getActivated() ? 'true' : 'false',
+                'activate' => 'false',
                 'entrypoint' => $deployment->getEntrypoint(),
             ]
         );
@@ -2828,7 +2828,7 @@ class Appwrite extends Destination
             [
                 'functionId' => $functionId,
                 'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                'activate' => $deployment->getActivated() ? 'true' : 'false',
+                'activate' => 'false',
                 'entrypoint' => $deployment->getEntrypoint(),
             ]
         );
@@ -3637,7 +3637,7 @@ class Appwrite extends Destination
                 [
                     'siteId' => $siteId,
                     'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                    'activate' => $deployment->getActivated() ? 'true' : 'false',
+                    'activate' => 'false',
                 ]
             );
 
@@ -3662,7 +3662,7 @@ class Appwrite extends Destination
             [
                 'siteId' => $siteId,
                 'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                'activate' => $deployment->getActivated() ? 'true' : 'false',
+                'activate' => 'false',
             ]
         );
 
@@ -3720,7 +3720,7 @@ class Appwrite extends Destination
             [
                 'siteId' => $siteId,
                 'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
-                'activate' => $deployment->getActivated() ? 'true' : 'false',
+                'activate' => 'false',
             ]
         );
 

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2137,20 +2137,15 @@ class Appwrite extends Destination
             if ($file->getStart() === 0) {
                 $existingFile = $this->getSdkResourceOrNull(fn () => $this->storage->getFile($bucketId, $fileId));
 
-                $handled = $this->handleDuplicate(
-                    $file,
-                    $existingFile !== null,
-                    $existingFile?->updatedAt,
-                    overwrite: fn () => $file->setStatus(
-                        Resource::STATUS_SKIPPED,
-                        'Already exists on destination; file overwrite requires delete-before-upload'
-                    ),
-                );
-
-                if ($handled && $file->getStatus() === Resource::STATUS_SKIPPED) {
+                if ($existingFile !== null && $this->onDuplicate === OnDuplicate::Skip) {
                     $this->skippedChunkedUploads['file:' . $fileId] = true;
+                    $file->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
                     $file->setData('');
                     return $file;
+                }
+
+                if ($existingFile !== null && $this->onDuplicate === OnDuplicate::Overwrite) {
+                    $this->storage->deleteFile($bucketId, $fileId);
                 }
             } elseif (isset($this->skippedChunkedUploads['file:' . $fileId])) {
                 $file->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
@@ -2658,20 +2653,15 @@ class Appwrite extends Destination
                 fn () => $this->functions->getDeployment($functionId, $deploymentId)
             );
 
-            $handled = $this->handleDuplicate(
-                $deployment,
-                $existingDeployment !== null,
-                $existingDeployment?->updatedAt,
-                overwrite: fn () => $deployment->setStatus(
-                    Resource::STATUS_SKIPPED,
-                    'Already exists on destination; deployment overwrite requires delete-before-upload'
-                ),
-            );
-
-            if ($handled && $deployment->getStatus() === Resource::STATUS_SKIPPED) {
+            if ($existingDeployment !== null && $this->onDuplicate === OnDuplicate::Skip) {
                 $this->skippedChunkedUploads['deployment:' . $deploymentId] = true;
+                $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
                 $deployment->setData('');
                 return $deployment;
+            }
+
+            if ($existingDeployment !== null && $this->onDuplicate === OnDuplicate::Overwrite) {
+                $this->functions->deleteDeployment($functionId, $deploymentId);
             }
         } elseif (isset($this->skippedChunkedUploads['deployment:' . $deploymentId])) {
             $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
@@ -3555,20 +3545,15 @@ class Appwrite extends Destination
                 fn () => $this->sites->getDeployment($siteId, $deploymentId)
             );
 
-            $handled = $this->handleDuplicate(
-                $deployment,
-                $existingDeployment !== null,
-                $existingDeployment?->updatedAt,
-                overwrite: fn () => $deployment->setStatus(
-                    Resource::STATUS_SKIPPED,
-                    'Already exists on destination; deployment overwrite requires delete-before-upload'
-                ),
-            );
-
-            if ($handled && $deployment->getStatus() === Resource::STATUS_SKIPPED) {
+            if ($existingDeployment !== null && $this->onDuplicate === OnDuplicate::Skip) {
                 $this->skippedChunkedUploads['site-deployment:' . $deploymentId] = true;
+                $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
                 $deployment->setData('');
                 return $deployment;
+            }
+
+            if ($existingDeployment !== null && $this->onDuplicate === OnDuplicate::Overwrite) {
+                $this->sites->deleteDeployment($siteId, $deploymentId);
             }
         } elseif (isset($this->skippedChunkedUploads['site-deployment:' . $deploymentId])) {
             $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -15,6 +15,7 @@ use Appwrite\Enums\Runtime;
 use Appwrite\Enums\SmtpEncryption;
 use Appwrite\Enums\StatusCode;
 use Appwrite\InputFile;
+use Appwrite\Query as SdkQuery;
 use Appwrite\Services\Functions;
 use Appwrite\Services\Messaging;
 use Appwrite\Services\Project;
@@ -165,6 +166,16 @@ class Appwrite extends Destination
     private array $processedTwoWayPairs = [];
 
     /**
+     * Chunked uploads (currently: files) call their import method once per
+     * chunk on the same resource object — the skip/overwrite decision is only
+     * evaluated on the first chunk, and this records a "skip" verdict so later
+     * chunks of the same upload don't re-upload. Keyed by "{type}:{id}".
+     *
+     * @var array<string, true>
+     */
+    private array $skippedChunkedUploads = [];
+
+    /**
      * @param string $project
      * @param string $endpoint
      * @param string $key
@@ -242,6 +253,7 @@ class Appwrite extends Destination
         $this->rowBuffer = [];
         $this->orphansByTable = [];
         $this->processedTwoWayPairs = [];
+        $this->skippedChunkedUploads = [];
     }
 
     public static function getName(): string
@@ -2014,6 +2026,67 @@ class Appwrite extends Destination
     }
 
     /**
+     * Skip/overwrite gate for re-migration — a Template Method around the
+     * existing `OnDuplicate::resolveSchemaAction` decision.
+     *
+     * `fail` (the default) always returns false immediately, without even
+     * looking at $exists. That means every caller's normal create path
+     * — whatever it does today — runs completely untouched. This function
+     * only ever changes behavior when the mode is `skip` or `overwrite`.
+     *
+     * @param callable(): void $overwrite update-in-place, or delete + recreate
+     * @return bool true when this call fully handled the resource (it was
+     *              skipped, or $overwrite ran) — the caller must not run its
+     *              own create logic. False — the caller should proceed with
+     *              its existing create path (covers both "fail" and
+     *              "doesn't exist on destination yet").
+     */
+    protected function resolveDuplicate(
+        Resource $resource,
+        bool $exists,
+        ?string $destUpdatedAt,
+        callable $overwrite,
+    ): bool {
+        if ($this->onDuplicate === OnDuplicate::Fail) {
+            return false;
+        }
+
+        switch ($this->onDuplicate->resolveSchemaAction($exists, $resource->getUpdatedAt(), $destUpdatedAt)) {
+            case SchemaAction::Skip:
+                $resource->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
+                return true;
+            case SchemaAction::Overwrite:
+                $overwrite();
+                return true;
+            case SchemaAction::Create:
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Existence check for SDK-backed resources. Returns the fetched model, or
+     * null when the SDK reports 404 ("not found"); any other AppwriteException
+     * re-throws — a scope/network/server error must surface as a failure, not
+     * be silently treated as "doesn't exist yet".
+     *
+     * @template T
+     * @param callable(): T $get
+     * @return T|null
+     */
+    protected function sdkGetOrNull(callable $get): mixed
+    {
+        try {
+            return $get();
+        } catch (AppwriteException $e) {
+            if ($e->getCode() === 404) {
+                return null;
+            }
+            throw $e;
+        }
+    }
+
+    /**
      * @throws AppwriteException
      */
     public function importFileResource(Resource $resource): Resource
@@ -2033,6 +2106,31 @@ class Appwrite extends Destination
                     default => throw new \Exception('Invalid Compression: ' . $resource->getCompression(), Exception::CODE_VALIDATION),
                 };
 
+                if ($this->onDuplicate !== OnDuplicate::Fail) {
+                    $existingBucket = $this->sdkGetOrNull(fn () => $this->storage->getBucket($resource->getId()));
+
+                    if ($this->resolveDuplicate(
+                        $resource,
+                        $existingBucket !== null,
+                        $existingBucket?->updatedAt,
+                        overwrite: fn () => $this->storage->updateBucket(
+                            $resource->getId(),
+                            $resource->getBucketName(),
+                            $resource->getPermissions(),
+                            $resource->getFileSecurity(),
+                            $resource->getEnabled(),
+                            $resource->getMaxFileSize(),
+                            $resource->getAllowedFileExtensions(),
+                            $compression,
+                            $resource->getEncryption(),
+                            $resource->getAntiVirus(),
+                            $resource->getTransformations()
+                        ),
+                    )) {
+                        break;
+                    }
+                }
+
                 $response = $this->storage->createBucket(
                     $resource->getId(),
                     $resource->getBucketName(),
@@ -2050,7 +2148,9 @@ class Appwrite extends Destination
                 $resource->setId($response->id);
         }
 
-        $resource->setStatus(Resource::STATUS_SUCCESS);
+        if ($resource->getStatus() !== Resource::STATUS_SKIPPED) {
+            $resource->setStatus(Resource::STATUS_SUCCESS);
+        }
 
         return $resource;
     }
@@ -2064,6 +2164,36 @@ class Appwrite extends Destination
     public function importFile(File $file): File
     {
         $bucketId = $file->getBucket()->getId();
+        $fileId = $file->getId();
+
+        // Chunked uploads call importFile() once per chunk (same File object,
+        // start/end advancing each time) — the duplicate decision only makes
+        // sense once, on the first chunk. Later chunks of a file skipped on
+        // chunk 0 must also be skipped, since the framework resets status to
+        // PROCESSING before every call. `fail` never reaches this block, so
+        // its upload path (and the 5xx/small-file split below) is untouched.
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            if ($file->getStart() === 0) {
+                $existingFile = $this->sdkGetOrNull(fn () => $this->storage->getFile($bucketId, $fileId));
+
+                $handled = $this->resolveDuplicate(
+                    $file,
+                    $existingFile !== null,
+                    $existingFile?->updatedAt,
+                    overwrite: fn () => $this->storage->deleteFile($bucketId, $fileId),
+                );
+
+                if ($handled && $file->getStatus() === Resource::STATUS_SKIPPED) {
+                    $this->skippedChunkedUploads['file:' . $fileId] = true;
+                    $file->setData('');
+                    return $file;
+                }
+            } elseif (isset($this->skippedChunkedUploads['file:' . $fileId])) {
+                $file->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
+                $file->setData('');
+                return $file;
+            }
+        }
 
         $response = null;
 
@@ -2129,6 +2259,19 @@ class Appwrite extends Destination
         switch ($resource->getName()) {
             case Resource::TYPE_USER:
                 /** @var User $resource */
+                if ($this->onDuplicate !== OnDuplicate::Fail) {
+                    $existingUser = $this->sdkGetOrNull(fn () => $this->users->get($resource->getId()));
+
+                    if ($this->resolveDuplicate(
+                        $resource,
+                        $existingUser !== null,
+                        $existingUser?->updatedAt,
+                        overwrite: fn () => $this->applyUserState($resource),
+                    )) {
+                        break;
+                    }
+                }
+
                 if (!empty($resource->getPasswordHash())) {
                     $this->importPasswordUser($resource);
                 } else {
@@ -2141,53 +2284,61 @@ class Appwrite extends Destination
                     );
                 }
 
-                if (!empty($resource->getUsername())) {
-                    $this->users->updateName($resource->getId(), $resource->getUsername());
-                }
-
-                if (!empty($resource->getPhone())) {
-                    $this->users->updatePhone($resource->getId(), $resource->getPhone());
-                }
-
-                if ($resource->getEmailVerified()) {
-                    $this->users->updateEmailVerification($resource->getId(), true);
-                }
-
-                if ($resource->getPhoneVerified()) {
-                    $this->users->updatePhoneVerification($resource->getId(), true);
-                }
-
-                if ($resource->getDisabled()) {
-                    $this->users->updateStatus($resource->getId(), false);
-                }
-
-                if (!empty($resource->getPreferences())) {
-                    $this->users->updatePrefs($resource->getId(), $resource->getPreferences());
-                }
-
-                if (!empty($resource->getLabels())) {
-                    $this->users->updateLabels($resource->getId(), $resource->getLabels());
-                }
-
-                if (!empty($resource->getTargets())) {
-                    $this->importUserTargets($resource->getId(), $resource->getTargets());
-                }
+                $this->applyUserState($resource);
 
                 break;
             case Resource::TYPE_TEAM:
                 /** @var Team $resource */
-                $this->teams->create($resource->getId(), $resource->getTeamName());
+                if ($this->onDuplicate !== OnDuplicate::Fail) {
+                    $existingTeam = $this->sdkGetOrNull(fn () => $this->teams->get($resource->getId()));
 
-                if (!empty($resource->getPreferences())) {
-                    $this->teams->updatePrefs($resource->getId(), $resource->getPreferences());
+                    if ($this->resolveDuplicate(
+                        $resource,
+                        $existingTeam !== null,
+                        $existingTeam?->updatedAt,
+                        overwrite: function () use ($resource): void {
+                            $this->teams->updateName($resource->getId(), $resource->getTeamName());
+                            $this->applyTeamState($resource);
+                        },
+                    )) {
+                        break;
+                    }
                 }
+
+                $this->teams->create($resource->getId(), $resource->getTeamName());
+                $this->applyTeamState($resource);
                 break;
             case Resource::TYPE_MEMBERSHIP:
                 /** @var Membership $resource */
+                $teamId = $resource->getTeam()->getId();
                 $user = $resource->getUser();
 
+                if ($this->onDuplicate !== OnDuplicate::Fail) {
+                    // createMembership() doesn't accept a caller-supplied ID —
+                    // the destination always mints its own, so it never
+                    // matches the source membership ID. Look up the existing
+                    // membership by (team, user) instead.
+                    $existingMemberships = $this->teams->listMemberships($teamId, [
+                        SdkQuery::equal('userId', [$user->getId()]),
+                    ]);
+                    $existingMembership = $existingMemberships->memberships[0] ?? null;
+
+                    if ($this->resolveDuplicate(
+                        $resource,
+                        $existingMembership !== null,
+                        $existingMembership?->updatedAt,
+                        overwrite: fn () => $this->teams->updateMembership(
+                            $teamId,
+                            $existingMembership->id,
+                            $resource->getRoles(),
+                        ),
+                    )) {
+                        break;
+                    }
+                }
+
                 $this->teams->createMembership(
-                    $resource->getTeam()->getId(),
+                    $teamId,
                     $resource->getRoles(),
                     userId: $user->getId(),
                 );
@@ -2206,9 +2357,59 @@ class Appwrite extends Destination
                 break;
         }
 
-        $resource->setStatus(Resource::STATUS_SUCCESS);
+        if ($resource->getStatus() !== Resource::STATUS_SKIPPED) {
+            $resource->setStatus(Resource::STATUS_SUCCESS);
+        }
 
         return $resource;
+    }
+
+    /**
+     * Applies every User field that isn't set at creation time. Shared by the
+     * create path (runs right after `users->create`/`importPasswordUser`,
+     * same as before this method existed) and the overwrite path.
+     */
+    private function applyUserState(User $resource): void
+    {
+        if (!empty($resource->getUsername())) {
+            $this->users->updateName($resource->getId(), $resource->getUsername());
+        }
+
+        if (!empty($resource->getPhone())) {
+            $this->users->updatePhone($resource->getId(), $resource->getPhone());
+        }
+
+        if ($resource->getEmailVerified()) {
+            $this->users->updateEmailVerification($resource->getId(), true);
+        }
+
+        if ($resource->getPhoneVerified()) {
+            $this->users->updatePhoneVerification($resource->getId(), true);
+        }
+
+        if ($resource->getDisabled()) {
+            $this->users->updateStatus($resource->getId(), false);
+        }
+
+        if (!empty($resource->getPreferences())) {
+            $this->users->updatePrefs($resource->getId(), $resource->getPreferences());
+        }
+
+        if (!empty($resource->getLabels())) {
+            $this->users->updateLabels($resource->getId(), $resource->getLabels());
+        }
+
+        if (!empty($resource->getTargets())) {
+            $this->importUserTargets($resource->getId(), $resource->getTargets());
+        }
+    }
+
+    /** Shared by the create and overwrite paths, same reasoning as applyUserState(). */
+    private function applyTeamState(Team $resource): void
+    {
+        if (!empty($resource->getPreferences())) {
+            $this->teams->updatePrefs($resource->getId(), $resource->getPreferences());
+        }
     }
 
     /**
@@ -2313,6 +2514,34 @@ class Appwrite extends Destination
                     throw new \Exception('Invalid Runtime: ' . $resource->getRuntime(), Exception::CODE_VALIDATION, $e);
                 }
 
+                if ($this->onDuplicate !== OnDuplicate::Fail) {
+                    $existingFunction = $this->sdkGetOrNull(fn () => $this->functions->get($resource->getId()));
+
+                    if ($this->resolveDuplicate(
+                        $resource,
+                        $existingFunction !== null,
+                        $existingFunction?->updatedAt,
+                        overwrite: fn () => $this->functions->update(
+                            functionId: $resource->getId(),
+                            name: $resource->getFunctionName(),
+                            runtime: $runtime,
+                            execute: $resource->getExecute(),
+                            events: $resource->getEvents(),
+                            schedule: $resource->getSchedule(),
+                            timeout: $resource->getTimeout(),
+                            enabled: $resource->getEnabled(),
+                            logging: $resource->getLogging(),
+                            entrypoint: $resource->getEntrypoint(),
+                            commands: $resource->getCommands(),
+                            scopes: $resource->getScopes(),
+                            buildSpecification: $resource->getSpecification() ?: null,
+                            runtimeSpecification: $resource->getSpecification() ?: null,
+                        ),
+                    )) {
+                        break;
+                    }
+                }
+
                 $this->functions->create(
                     functionId: $resource->getId(),
                     name: $resource->getFunctionName(),
@@ -2332,8 +2561,30 @@ class Appwrite extends Destination
                 break;
             case Resource::TYPE_ENVIRONMENT_VARIABLE:
                 /** @var EnvVar $resource */
+                $functionId = $resource->getFunc()->getId();
+
+                if ($this->onDuplicate !== OnDuplicate::Fail) {
+                    $existingVariable = $this->sdkGetOrNull(
+                        fn () => $this->functions->getVariable($functionId, $resource->getId())
+                    );
+
+                    if ($this->resolveDuplicate(
+                        $resource,
+                        $existingVariable !== null,
+                        $existingVariable?->updatedAt,
+                        overwrite: fn () => $this->functions->updateVariable(
+                            functionId: $functionId,
+                            variableId: $resource->getId(),
+                            key: $resource->getKey(),
+                            value: $resource->getValue(),
+                        ),
+                    )) {
+                        break;
+                    }
+                }
+
                 $this->functions->createVariable(
-                    functionId: $resource->getFunc()->getId(),
+                    functionId: $functionId,
                     variableId: $resource->getId(),
                     key: $resource->getKey(),
                     value: $resource->getValue(),
@@ -2344,7 +2595,9 @@ class Appwrite extends Destination
                 return $this->importDeployment($resource);
         }
 
-        $resource->setStatus(Resource::STATUS_SUCCESS);
+        if ($resource->getStatus() !== Resource::STATUS_SKIPPED) {
+            $resource->setStatus(Resource::STATUS_SUCCESS);
+        }
 
         return $resource;
     }
@@ -2364,15 +2617,23 @@ class Appwrite extends Destination
     {
         $function = $deployment->getFunction();
 
-        // Deployment API always creates a new deployment, so unlike other resources
-        // there's no duplicate detection. Skip if the parent function wasn't imported successfully.
-        if ($function->getStatus() !== Resource::STATUS_SUCCESS) {
+        // The parent function must exist on the destination for its deployments
+        // to attach. SUCCESS = just created/overwritten; SKIPPED = already
+        // existed (Skip mode, or Overwrite with nothing newer) — in both cases
+        // it's present, so proceed and let the per-deployment duplicate check
+        // create whatever is missing. Any other status means it genuinely
+        // isn't there.
+        if (!\in_array($function->getStatus(), [Resource::STATUS_SUCCESS, Resource::STATUS_SKIPPED], true)) {
             $deployment->setStatus(Resource::STATUS_SKIPPED, 'Parent function "' . $function->getId() . '" failed to import');
 
             return $deployment;
         }
 
         $functionId = $function->getId();
+
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            return $this->importDeploymentWithDuplicateCheck($deployment, $functionId);
+        }
 
         $response = null;
 
@@ -2432,6 +2693,77 @@ class Appwrite extends Destination
     }
 
     /**
+     * Skip/overwrite path for deployments — a deliberately separate path from
+     * importDeployment()'s `fail` upload logic above, not a shared one.
+     *
+     * The deployment endpoint only honors a caller-supplied ID (`x-appwrite-id`)
+     * on the chunked/content-range request shape, which importDeployment()'s
+     * small-file branch never sends — so under `fail` the destination ID is
+     * always random and no existence check is possible. Forcing that header
+     * unconditionally here (even for a single-chunk upload covering the whole
+     * file) makes the destination ID deterministic, which is what lets the
+     * existence check below work at all.
+     */
+    private function importDeploymentWithDuplicateCheck(Deployment $deployment, string $functionId): Resource
+    {
+        $deploymentId = $deployment->getId();
+
+        // The duplicate decision only runs once, on the first chunk — see
+        // importFile() for why chunked uploads need this guard.
+        if ($deployment->getStart() === 0) {
+            $existingDeployment = $this->sdkGetOrNull(
+                fn () => $this->functions->getDeployment($functionId, $deploymentId)
+            );
+
+            $handled = $this->resolveDuplicate(
+                $deployment,
+                $existingDeployment !== null,
+                $existingDeployment?->updatedAt,
+                overwrite: fn () => $this->functions->deleteDeployment($functionId, $deploymentId),
+            );
+
+            if ($handled && $deployment->getStatus() === Resource::STATUS_SKIPPED) {
+                $this->skippedChunkedUploads['deployment:' . $deploymentId] = true;
+                $deployment->setData('');
+                return $deployment;
+            }
+        } elseif (isset($this->skippedChunkedUploads['deployment:' . $deploymentId])) {
+            $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
+            $deployment->setData('');
+            return $deployment;
+        }
+
+        $response = $this->client->call(
+            'POST',
+            "/functions/{$functionId}/deployments",
+            [
+                'content-type' => 'multipart/form-data',
+                'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . ($deployment->getEnd() == ($deployment->getSize() - 1) ? $deployment->getSize() : $deployment->getEnd()) . '/' . $deployment->getSize(),
+                'x-appwrite-id' => $deploymentId,
+                'X-Appwrite-Project' => $this->projectId,
+            ],
+            [
+                'functionId' => $functionId,
+                'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
+                'activate' => $deployment->getActivated() ? 'true' : 'false',
+                'entrypoint' => $deployment->getEntrypoint(),
+            ]
+        );
+
+        if (!\is_array($response) || !isset($response['$id'])) {
+            throw new \Exception('Deployment creation failed', Exception::CODE_INTERNAL);
+        }
+
+        if ($deployment->getEnd() == ($deployment->getSize() - 1)) {
+            $deployment->setStatus(Resource::STATUS_SUCCESS);
+        } else {
+            $deployment->setStatus(Resource::STATUS_PENDING);
+        }
+
+        return $deployment;
+    }
+
+    /**
      * @throws AppwriteException
      * @throws \Exception
      */
@@ -2458,7 +2790,9 @@ class Appwrite extends Destination
                 throw new \Exception('Unknown messaging resource type: ' . $resource->getName());
         }
 
-        $resource->setStatus(Resource::STATUS_SUCCESS);
+        if ($resource->getStatus() !== Resource::STATUS_SKIPPED) {
+            $resource->setStatus(Resource::STATUS_SUCCESS);
+        }
 
         return $resource;
     }
@@ -2502,6 +2836,34 @@ class Appwrite extends Destination
                     default => null,
                 };
 
+                if ($this->onDuplicate !== OnDuplicate::Fail) {
+                    $existingSite = $this->sdkGetOrNull(fn () => $this->sites->get($resource->getId()));
+
+                    if ($this->resolveDuplicate(
+                        $resource,
+                        $existingSite !== null,
+                        $existingSite?->updatedAt,
+                        overwrite: fn () => $this->sites->update(
+                            siteId: $resource->getId(),
+                            name: $resource->getSiteName(),
+                            framework: $framework,
+                            buildRuntime: $buildRuntime,
+                            enabled: $resource->getEnabled(),
+                            logging: $resource->getLogging(),
+                            timeout: $resource->getTimeout(),
+                            installCommand: $resource->getInstallCommand(),
+                            buildCommand: $resource->getBuildCommand(),
+                            outputDirectory: $resource->getOutputDirectory(),
+                            adapter: $adapter,
+                            fallbackFile: $resource->getFallbackFile(),
+                            buildSpecification: $resource->getSpecification() ?: null,
+                            runtimeSpecification: $resource->getSpecification() ?: null,
+                        ),
+                    )) {
+                        break;
+                    }
+                }
+
                 $this->sites->create(
                     siteId: $resource->getId(),
                     name: $resource->getSiteName(),
@@ -2521,8 +2883,30 @@ class Appwrite extends Destination
                 break;
             case Resource::TYPE_SITE_VARIABLE:
                 /** @var SiteEnvVar $resource */
+                $siteId = $resource->getSite()->getId();
+
+                if ($this->onDuplicate !== OnDuplicate::Fail) {
+                    $existingSiteVariable = $this->sdkGetOrNull(
+                        fn () => $this->sites->getVariable($siteId, $resource->getId())
+                    );
+
+                    if ($this->resolveDuplicate(
+                        $resource,
+                        $existingSiteVariable !== null,
+                        $existingSiteVariable?->updatedAt,
+                        overwrite: fn () => $this->sites->updateVariable(
+                            siteId: $siteId,
+                            variableId: $resource->getId(),
+                            key: $resource->getKey(),
+                            value: $resource->getValue(),
+                        ),
+                    )) {
+                        break;
+                    }
+                }
+
                 $this->sites->createVariable(
-                    siteId: $resource->getSite()->getId(),
+                    siteId: $siteId,
                     variableId: $resource->getId(),
                     key: $resource->getKey(),
                     value: $resource->getValue(),
@@ -2533,7 +2917,9 @@ class Appwrite extends Destination
                 return $this->importSiteDeployment($resource);
         }
 
-        $resource->setStatus(Resource::STATUS_SUCCESS);
+        if ($resource->getStatus() !== Resource::STATUS_SKIPPED) {
+            $resource->setStatus(Resource::STATUS_SUCCESS);
+        }
 
         return $resource;
     }
@@ -2555,6 +2941,13 @@ class Appwrite extends Destination
                     // Auto-created by the server when a user is created with an email/phone
                     break;
                 case 'push':
+                    // Overwriting a User already carrying this target: target IDs
+                    // aren't otherwise reconciled, so treat an existing one as
+                    // already up to date rather than erroring on re-migration.
+                    if (!$this->dbForProject->getDocument('targets', $target['$id'])->isEmpty()) {
+                        break;
+                    }
+
                     $userDoc ??= $this->dbForProject->getDocument('users', $userId);
 
                     $createdAt = $this->normalizeDateTime($target['$createdAt'] ?? null);
@@ -2591,6 +2984,28 @@ class Appwrite extends Destination
      * @throws \Exception
      */
     protected function createProvider(Provider $resource): void
+    {
+        $id = $resource->getId();
+
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            $existingProvider = $this->sdkGetOrNull(fn () => $this->messaging->getProvider($id));
+
+            if ($this->resolveDuplicate(
+                $resource,
+                $existingProvider !== null,
+                $existingProvider?->updatedAt,
+                overwrite: fn () => $this->updateProviderOnDestination($resource),
+            )) {
+                $this->reconcileProviderTargets($id);
+                return;
+            }
+        }
+
+        $this->createProviderOnDestination($resource);
+        $this->reconcileProviderTargets($id);
+    }
+
+    private function createProviderOnDestination(Provider $resource): void
     {
         $credentials = $resource->getCredentials();
         $options = $resource->getOptions();
@@ -2709,9 +3124,135 @@ class Appwrite extends Destination
             ),
             default => throw new \Exception('Unknown provider: ' . $resource->getProvider()),
         };
+    }
 
-        // Resolve providerInternalId for push targets that were written during GROUP_AUTH
-        // before the provider existed on the destination.
+    private function updateProviderOnDestination(Provider $resource): void
+    {
+        $credentials = $resource->getCredentials();
+        $options = $resource->getOptions();
+        $id = $resource->getId();
+        $name = $resource->getProviderName();
+        $enabled = $resource->getEnabled();
+
+        match ($resource->getProvider()) {
+            'mailgun' => $this->messaging->updateMailgunProvider(
+                $id,
+                $name,
+                $credentials['apiKey'] ?? null,
+                $credentials['domain'] ?? null,
+                $enabled,
+                $credentials['isEuRegion'] ?? null,
+                ($options['fromName'] ?? '') ?: null,
+                ($options['fromEmail'] ?? '') ?: null,
+                ($options['replyToName'] ?? '') ?: null,
+                ($options['replyToEmail'] ?? '') ?: null,
+            ),
+            'sendgrid' => $this->messaging->updateSendgridProvider(
+                $id,
+                $name,
+                $enabled,
+                $credentials['apiKey'] ?? null,
+                ($options['fromName'] ?? '') ?: null,
+                ($options['fromEmail'] ?? '') ?: null,
+                ($options['replyToName'] ?? '') ?: null,
+                ($options['replyToEmail'] ?? '') ?: null,
+            ),
+            'resend' => $this->messaging->updateResendProvider(
+                $id,
+                $name,
+                $enabled,
+                $credentials['apiKey'] ?? null,
+                ($options['fromName'] ?? '') ?: null,
+                ($options['fromEmail'] ?? '') ?: null,
+                ($options['replyToName'] ?? '') ?: null,
+                ($options['replyToEmail'] ?? '') ?: null,
+            ),
+            'smtp' => $this->messaging->updateSmtpProvider(
+                $id,
+                $name,
+                $credentials['host'] ?? '',
+                $credentials['port'] ?? null,
+                ($credentials['username'] ?? '') ?: null,
+                ($credentials['password'] ?? '') ?: null,
+                match ($options['encryption'] ?? '') {
+                    'ssl' => SmtpEncryption::SSL(),
+                    'tls' => SmtpEncryption::TLS(),
+                    default => SmtpEncryption::NONE(),
+                },
+                $options['autoTLS'] ?? null,
+                ($options['mailer'] ?? '') ?: null,
+                ($options['fromName'] ?? '') ?: null,
+                ($options['fromEmail'] ?? '') ?: null,
+                ($options['replyToName'] ?? '') ?: null,
+                ($options['replyToEmail'] ?? '') ?: null,
+                $enabled,
+            ),
+            'msg91' => $this->messaging->updateMsg91Provider(
+                $id,
+                $name,
+                $credentials['templateId'] ?? null,
+                $credentials['senderId'] ?? null,
+                $credentials['authKey'] ?? null,
+                $enabled,
+            ),
+            'telesign' => $this->messaging->updateTelesignProvider(
+                $id,
+                $name,
+                ($options['from'] ?? '') ?: null,
+                $credentials['customerId'] ?? null,
+                $credentials['apiKey'] ?? null,
+                $enabled,
+            ),
+            'textmagic' => $this->messaging->updateTextmagicProvider(
+                $id,
+                $name,
+                ($options['from'] ?? '') ?: null,
+                $credentials['username'] ?? null,
+                $credentials['apiKey'] ?? null,
+                $enabled,
+            ),
+            'twilio' => $this->messaging->updateTwilioProvider(
+                $id,
+                $name,
+                ($options['from'] ?? '') ?: null,
+                $credentials['accountSid'] ?? null,
+                $credentials['authToken'] ?? null,
+                $enabled,
+            ),
+            'vonage' => $this->messaging->updateVonageProvider(
+                $id,
+                $name,
+                ($options['from'] ?? '') ?: null,
+                $credentials['apiKey'] ?? null,
+                $credentials['apiSecret'] ?? null,
+                $enabled,
+            ),
+            'fcm' => $this->messaging->updateFcmProvider(
+                $id,
+                $name,
+                $credentials['serviceAccountJSON'] ?? null,
+                $enabled,
+            ),
+            'apns' => $this->messaging->updateApnsProvider(
+                $id,
+                $name,
+                $credentials['authKey'] ?? null,
+                $credentials['authKeyId'] ?? null,
+                $credentials['teamId'] ?? null,
+                $credentials['bundleId'] ?? null,
+                $enabled,
+                $options['sandbox'] ?? null,
+            ),
+            default => throw new \Exception('Unknown provider: ' . $resource->getProvider()),
+        };
+    }
+
+    /**
+     * Resolve providerInternalId for push targets that were written during
+     * GROUP_AUTH before the provider existed on the destination.
+     */
+    private function reconcileProviderTargets(string $id): void
+    {
         $provider = $this->dbForProject->getDocument('providers', $id);
         $targets = $this->dbForProject->find('targets', [
             Query::equal('providerId', [$id]),
@@ -2736,8 +3277,27 @@ class Appwrite extends Destination
      */
     protected function createTopic(Topic $resource): void
     {
+        $id = $resource->getId();
+
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            $existingTopic = $this->sdkGetOrNull(fn () => $this->messaging->getTopic($id));
+
+            if ($this->resolveDuplicate(
+                $resource,
+                $existingTopic !== null,
+                $existingTopic?->updatedAt,
+                overwrite: fn () => $this->messaging->updateTopic(
+                    $id,
+                    $resource->getTopicName(),
+                    $resource->getSubscribe(),
+                ),
+            )) {
+                return;
+            }
+        }
+
         $this->messaging->createTopic(
-            $resource->getId(),
+            $id,
             $resource->getTopicName(),
             $resource->getSubscribe(),
         );
@@ -2749,6 +3309,30 @@ class Appwrite extends Destination
      * @throws DatabaseException|\Exception
      */
     protected function createSubscriber(Subscriber $resource): void
+    {
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            $existing = $this->dbForProject->getDocument('subscribers', $resource->getId());
+
+            // No SDK update exists for a subscriber — overwrite deletes (via
+            // the SDK, so the topic's total is decremented for us) and
+            // recreates through the same logic as create.
+            if ($this->resolveDuplicate(
+                $resource,
+                !$existing->isEmpty(),
+                $existing->getUpdatedAt(),
+                overwrite: function () use ($resource): void {
+                    $this->messaging->deleteSubscriber($resource->getTopicId(), $resource->getId());
+                    $this->createSubscriberOnDestination($resource);
+                },
+            )) {
+                return;
+            }
+        }
+
+        $this->createSubscriberOnDestination($resource);
+    }
+
+    private function createSubscriberOnDestination(Subscriber $resource): void
     {
         $target = match ($resource->getProviderType()) {
             'push' => $this->dbForProject->getDocument('targets', $resource->getTargetId()),
@@ -2814,6 +3398,35 @@ class Appwrite extends Destination
      * @throws \Exception
      */
     protected function createMessage(Message $resource): void
+    {
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            $existing = $this->dbForProject->getDocument('messages', $resource->getId());
+
+            // The SDK's update* methods only work while a message is still a
+            // draft — a sent/scheduled message can't be updated, so overwrite
+            // deletes (cancelling any scheduled send) and recreates through
+            // the same logic as create.
+            if ($this->resolveDuplicate(
+                $resource,
+                !$existing->isEmpty(),
+                $existing->getUpdatedAt(),
+                overwrite: function () use ($resource): void {
+                    $this->messaging->delete($resource->getId());
+                    $this->createMessageOnDestination($resource);
+                },
+            )) {
+                return;
+            }
+        }
+
+        $this->createMessageOnDestination($resource);
+    }
+
+    /**
+     * @throws AppwriteException
+     * @throws \Exception
+     */
+    private function createMessageOnDestination(Message $resource): void
     {
         $resolvedTargets = $resource->getTargets();
         $status = $resource->getMessageStatus();
@@ -2936,15 +3549,22 @@ class Appwrite extends Destination
     {
         $site = $deployment->getSite();
 
-        // Deployment API always creates a new deployment, so unlike other resources
-        // there's no duplicate detection. Skip if the parent site wasn't imported successfully.
-        if ($site->getStatus() !== Resource::STATUS_SUCCESS) {
+        // The parent site must exist on the destination for its deployments to
+        // attach. SUCCESS = just created/overwritten; SKIPPED = already existed
+        // (Skip mode, or Overwrite with nothing newer) — in both cases it's
+        // present, so proceed and let the per-deployment duplicate check create
+        // whatever is missing. Any other status means it genuinely isn't there.
+        if (!\in_array($site->getStatus(), [Resource::STATUS_SUCCESS, Resource::STATUS_SKIPPED], true)) {
             $deployment->setStatus(Resource::STATUS_SKIPPED, 'Parent site "' . $site->getId() . '" failed to import');
 
             return $deployment;
         }
 
         $siteId = $site->getId();
+
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            return $this->importSiteDeploymentWithDuplicateCheck($deployment, $siteId);
+        }
 
         if ($deployment->getSize() <= Transfer::STORAGE_MAX_CHUNK_SIZE) {
             $response = $this->client->call(
@@ -2992,6 +3612,63 @@ class Appwrite extends Destination
 
         if ($deployment->getStart() === 0) {
             $deployment->setId($response['$id']);
+        }
+
+        if ($deployment->getEnd() == ($deployment->getSize() - 1)) {
+            $deployment->setStatus(Resource::STATUS_SUCCESS);
+        } else {
+            $deployment->setStatus(Resource::STATUS_PENDING);
+        }
+
+        return $deployment;
+    }
+
+    /** Skip/overwrite path for site deployments — mirrors importDeploymentWithDuplicateCheck(), see that docblock. */
+    private function importSiteDeploymentWithDuplicateCheck(SiteDeployment $deployment, string $siteId): Resource
+    {
+        $deploymentId = $deployment->getId();
+
+        if ($deployment->getStart() === 0) {
+            $existingDeployment = $this->sdkGetOrNull(
+                fn () => $this->sites->getDeployment($siteId, $deploymentId)
+            );
+
+            $handled = $this->resolveDuplicate(
+                $deployment,
+                $existingDeployment !== null,
+                $existingDeployment?->updatedAt,
+                overwrite: fn () => $this->sites->deleteDeployment($siteId, $deploymentId),
+            );
+
+            if ($handled && $deployment->getStatus() === Resource::STATUS_SKIPPED) {
+                $this->skippedChunkedUploads['site-deployment:' . $deploymentId] = true;
+                $deployment->setData('');
+                return $deployment;
+            }
+        } elseif (isset($this->skippedChunkedUploads['site-deployment:' . $deploymentId])) {
+            $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
+            $deployment->setData('');
+            return $deployment;
+        }
+
+        $response = $this->client->call(
+            'POST',
+            "/sites/{$siteId}/deployments",
+            [
+                'content-type' => 'multipart/form-data',
+                'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . ($deployment->getEnd() == ($deployment->getSize() - 1) ? $deployment->getSize() : $deployment->getEnd()) . '/' . $deployment->getSize(),
+                'x-appwrite-id' => $deploymentId,
+                'X-Appwrite-Project' => $this->projectId,
+            ],
+            [
+                'siteId' => $siteId,
+                'code' => new \CURLFile('data://application/gzip;base64,' . base64_encode($deployment->getData()), 'application/gzip', 'deployment.tar.gz'),
+                'activate' => $deployment->getActivated() ? 'true' : 'false',
+            ]
+        );
+
+        if (!\is_array($response) || !isset($response['$id'])) {
+            throw new \Exception('Site deployment creation failed', Exception::CODE_INTERNAL);
         }
 
         if ($deployment->getEnd() == ($deployment->getSize() - 1)) {
@@ -3091,8 +3768,23 @@ class Appwrite extends Destination
             Query::equal('resourceType', ['project']),
             Query::equal('key', [$resource->getKey()]),
         ]);
+        $existingDoc = ($existing !== false && !$existing->isEmpty()) ? $existing : null;
 
-        if ($existing !== false && !$existing->isEmpty()) {
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            if ($this->resolveDuplicate(
+                $resource,
+                $existingDoc !== null,
+                $existingDoc?->getUpdatedAt(),
+                overwrite: fn () => $this->dbForProject->updateDocument('variables', $existingDoc->getId(), new UtopiaDocument([
+                    'value' => $resource->getValue(),
+                    'secret' => $resource->isSecret(),
+                ])),
+            )) {
+                return true;
+            }
+        }
+
+        if ($existingDoc !== null) {
             $resource->setStatus(Resource::STATUS_SKIPPED, 'Project variable already exists');
             return false;
         }
@@ -3255,6 +3947,38 @@ class Appwrite extends Destination
             return false;
         }
 
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            // The create endpoints don't accept a caller-supplied rule ID —
+            // the destination always assigns its own, so it never matches the
+            // source rule ID. Look up the existing rule by domain instead.
+            $existingRules = $this->proxy->listRules([
+                SdkQuery::equal('domain', [$resource->getDomain()]),
+            ]);
+            $existingRule = $existingRules->rules[0] ?? null;
+
+            $overwriteSucceeded = false;
+
+            $handled = $this->resolveDuplicate(
+                $resource,
+                $existingRule !== null,
+                $existingRule?->updatedAt,
+                // Rules have no update endpoint — overwrite deletes and recreates.
+                overwrite: function () use ($resource, $existingRule, &$overwriteSucceeded): void {
+                    $this->proxy->deleteRule($existingRule->id);
+                    $overwriteSucceeded = $this->createRuleOnDestination($resource);
+                },
+            );
+
+            if ($handled) {
+                return $overwriteSucceeded;
+            }
+        }
+
+        return $this->createRuleOnDestination($resource);
+    }
+
+    private function createRuleOnDestination(Rule $resource): bool
+    {
         $type = $resource->getType();
         $deploymentResourceType = $resource->getDeploymentResourceType();
         $branch = $resource->getDeploymentVcsProviderBranch();
@@ -3331,8 +4055,30 @@ class Appwrite extends Destination
             Query::equal('projectInternalId', [$this->projectInternalId]),
             Query::equal('name', [$resource->getWebhookName()]),
         ]);
+        $existingDoc = ($existing !== false && !$existing->isEmpty()) ? $existing : null;
 
-        if ($existing !== false && !$existing->isEmpty()) {
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            if ($this->resolveDuplicate(
+                $resource,
+                $existingDoc !== null,
+                $existingDoc?->getUpdatedAt(),
+                overwrite: function () use ($resource, $existingDoc): void {
+                    $this->dbForPlatform->updateDocument('webhooks', $existingDoc->getId(), new UtopiaDocument([
+                        'events' => $resource->getEvents(),
+                        'url' => $resource->getUrl(),
+                        'security' => $resource->getSecurity(),
+                        'httpUser' => $resource->getHttpUser(),
+                        'httpPass' => $resource->getHttpPass(),
+                        'enabled' => $resource->isEnabled(),
+                    ]));
+                    $this->dbForPlatform->purgeCachedDocument('projects', $this->projectId);
+                },
+            )) {
+                return true;
+            }
+        }
+
+        if ($existingDoc !== null) {
             $resource->setStatus(Resource::STATUS_SKIPPED, 'Webhook already exists');
             return false;
         }
@@ -3379,8 +4125,27 @@ class Appwrite extends Destination
             Query::equal('type', [$resource->getType()]),
             Query::equal('name', [$resource->getPlatformName()]),
         ]);
+        $existingDoc = ($existing !== false && !$existing->isEmpty()) ? $existing : null;
 
-        if ($existing !== false && !$existing->isEmpty()) {
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            if ($this->resolveDuplicate(
+                $resource,
+                $existingDoc !== null,
+                $existingDoc?->getUpdatedAt(),
+                overwrite: function () use ($resource, $existingDoc): void {
+                    $this->dbForPlatform->updateDocument('platforms', $existingDoc->getId(), new UtopiaDocument([
+                        'key' => $resource->getKey(),
+                        'store' => $resource->getStore(),
+                        'hostname' => $resource->getHostname(),
+                    ]));
+                    $this->dbForPlatform->purgeCachedDocument('projects', $this->projectId);
+                },
+            )) {
+                return true;
+            }
+        }
+
+        if ($existingDoc !== null) {
             $resource->setStatus(Resource::STATUS_SKIPPED, 'Platform already exists');
             return false;
         }
@@ -3536,8 +4301,32 @@ class Appwrite extends Destination
             Query::equal('resourceInternalId', [$this->projectInternalId]),
             Query::equal('name', [$resource->getApiKeyName()]),
         ]);
+        $existingDoc = ($existing !== false && !$existing->isEmpty()) ? $existing : null;
 
-        if ($existing !== false && !$existing->isEmpty()) {
+        if ($this->onDuplicate !== OnDuplicate::Fail) {
+            // Secret is intentionally not regenerated on overwrite — it's only
+            // ever set at creation, since rotating it would break whatever
+            // already uses it.
+            if ($this->resolveDuplicate(
+                $resource,
+                $existingDoc !== null,
+                $existingDoc?->getUpdatedAt(),
+                overwrite: function () use ($resource, $existingDoc): void {
+                    $expire = $resource->getExpire();
+
+                    $this->dbForPlatform->updateDocument('keys', $existingDoc->getId(), new UtopiaDocument([
+                        'scopes' => $resource->getScopes(),
+                        'expire' => empty($expire) ? null : $expire,
+                        'sdks' => $resource->getSdks(),
+                    ]));
+                    $this->dbForPlatform->purgeCachedDocument('projects', $this->projectId);
+                },
+            )) {
+                return true;
+            }
+        }
+
+        if ($existingDoc !== null) {
             $resource->setStatus(Resource::STATUS_SKIPPED, 'API key already exists');
             return false;
         }

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2079,11 +2079,19 @@ class Appwrite extends Destination
         try {
             return $get();
         } catch (AppwriteException $e) {
-            if ($e->getCode() === 404) {
+            if ($e->getCode() === Exception::CODE_NOT_FOUND) {
                 return null;
             }
             throw $e;
         }
+    }
+
+    private function skipReplaceOnlyOverwrite(Resource $resource, string $type): void
+    {
+        $resource->setStatus(
+            Resource::STATUS_SKIPPED,
+            "Already exists on destination; {$type} overwrite requires delete-before-upload"
+        );
     }
 
     /**
@@ -2180,7 +2188,7 @@ class Appwrite extends Destination
                     $file,
                     $existingFile !== null,
                     $existingFile?->updatedAt,
-                    overwrite: fn () => $this->storage->deleteFile($bucketId, $fileId),
+                    overwrite: fn () => $this->skipReplaceOnlyOverwrite($file, 'file'),
                 );
 
                 if ($handled && $file->getStatus() === Resource::STATUS_SKIPPED) {
@@ -2266,7 +2274,15 @@ class Appwrite extends Destination
                         $resource,
                         $existingUser !== null,
                         $existingUser?->updatedAt,
-                        overwrite: fn () => $this->applyUserState($resource),
+                        overwrite: function () use ($resource, $existingUser): void {
+                            if (!empty($resource->getEmail()) && $existingUser?->email !== $resource->getEmail()) {
+                                $this->users->updateEmail($resource->getId(), $resource->getEmail());
+                            }
+
+                            // Imported password hashes are only accepted by
+                            // Appwrite's hash-specific create endpoints.
+                            $this->applyUserState($resource);
+                        },
                     )) {
                         break;
                     }
@@ -2719,7 +2735,7 @@ class Appwrite extends Destination
                 $deployment,
                 $existingDeployment !== null,
                 $existingDeployment?->updatedAt,
-                overwrite: fn () => $this->functions->deleteDeployment($functionId, $deploymentId),
+                overwrite: fn () => $this->skipReplaceOnlyOverwrite($deployment, 'deployment'),
             );
 
             if ($handled && $deployment->getStatus() === Resource::STATUS_SKIPPED) {
@@ -3637,7 +3653,7 @@ class Appwrite extends Destination
                 $deployment,
                 $existingDeployment !== null,
                 $existingDeployment?->updatedAt,
-                overwrite: fn () => $this->sites->deleteDeployment($siteId, $deploymentId),
+                overwrite: fn () => $this->skipReplaceOnlyOverwrite($deployment, 'deployment'),
             );
 
             if ($handled && $deployment->getStatus() === Resource::STATUS_SKIPPED) {

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2330,7 +2330,7 @@ class Appwrite extends Destination
             "/storage/buckets/{$bucketId}/files",
             [
                 'content-type' => 'multipart/form-data',
-                'content-range' => 'bytes ' . ($file->getStart()) . '-' . ($file->getEnd() == ($file->getSize() - 1) ? $file->getSize() : $file->getEnd()) . '/' . $file->getSize(),
+                'content-range' => 'bytes ' . ($file->getStart()) . '-' . $file->getEnd() . '/' . $file->getSize(),
                 'X-Appwrite-Project' => $this->projectId,
             ],
             [
@@ -2762,7 +2762,7 @@ class Appwrite extends Destination
             "/v1/functions/{$functionId}/deployments",
             [
                 'content-type' => 'multipart/form-data',
-                'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . ($deployment->getEnd() == ($deployment->getSize() - 1) ? $deployment->getSize() : $deployment->getEnd()) . '/' . $deployment->getSize(),
+                'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . $deployment->getEnd() . '/' . $deployment->getSize(),
                 'x-appwrite-id' => $deployment->getId(),
                 'X-Appwrite-Project' => $this->projectId,
             ],
@@ -2808,7 +2808,13 @@ class Appwrite extends Destination
             }
 
             if ($existingDeployment !== null && $this->onDuplicate === OnDuplicate::Overwrite) {
-                $this->functions->deleteDeployment($functionId, $deploymentId);
+                try {
+                    $this->functions->deleteDeployment($functionId, $deploymentId);
+                } catch (AppwriteException $e) {
+                    if ($this->getSdkResourceOrNull(fn () => $this->functions->getDeployment($functionId, $deploymentId)) !== null) {
+                        throw $e;
+                    }
+                }
             }
         } elseif (isset($this->skippedChunkedUploads['deployment:' . $deploymentId])) {
             $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
@@ -2821,7 +2827,7 @@ class Appwrite extends Destination
             "/functions/{$functionId}/deployments",
             [
                 'content-type' => 'multipart/form-data',
-                'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . ($deployment->getEnd() == ($deployment->getSize() - 1) ? $deployment->getSize() : $deployment->getEnd()) . '/' . $deployment->getSize(),
+                'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . $deployment->getEnd() . '/' . $deployment->getSize(),
                 'x-appwrite-id' => $deploymentId,
                 'X-Appwrite-Project' => $this->projectId,
             ],
@@ -3655,7 +3661,7 @@ class Appwrite extends Destination
             "/sites/{$siteId}/deployments",
             [
                 'content-type' => 'multipart/form-data',
-                'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . ($deployment->getEnd() == ($deployment->getSize() - 1) ? $deployment->getSize() : $deployment->getEnd()) . '/' . $deployment->getSize(),
+                'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . $deployment->getEnd() . '/' . $deployment->getSize(),
                 'x-appwrite-id' => $deployment->getId(),
                 'X-Appwrite-Project' => $this->projectId,
             ],
@@ -3700,7 +3706,13 @@ class Appwrite extends Destination
             }
 
             if ($existingDeployment !== null && $this->onDuplicate === OnDuplicate::Overwrite) {
-                $this->sites->deleteDeployment($siteId, $deploymentId);
+                try {
+                    $this->sites->deleteDeployment($siteId, $deploymentId);
+                } catch (AppwriteException $e) {
+                    if ($this->getSdkResourceOrNull(fn () => $this->sites->getDeployment($siteId, $deploymentId)) !== null) {
+                        throw $e;
+                    }
+                }
             }
         } elseif (isset($this->skippedChunkedUploads['site-deployment:' . $deploymentId])) {
             $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
@@ -3713,7 +3725,7 @@ class Appwrite extends Destination
             "/sites/{$siteId}/deployments",
             [
                 'content-type' => 'multipart/form-data',
-                'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . ($deployment->getEnd() == ($deployment->getSize() - 1) ? $deployment->getSize() : $deployment->getEnd()) . '/' . $deployment->getSize(),
+                'content-range' => 'bytes ' . ($deployment->getStart()) . '-' . $deployment->getEnd() . '/' . $deployment->getSize(),
                 'x-appwrite-id' => $deploymentId,
                 'X-Appwrite-Project' => $this->projectId,
             ],

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2284,15 +2284,23 @@ class Appwrite extends Destination
             if ($file->getStart() === 0) {
                 $existingFile = $this->getSdkResourceOrNull(fn () => $this->storage->getFile($bucketId, $fileId));
 
-                if ($existingFile !== null && $this->onDuplicate === OnDuplicate::Skip) {
-                    $this->skippedChunkedUploads['file:' . $fileId] = true;
-                    $file->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
-                    $file->setData('');
-                    return $file;
-                }
+                if ($existingFile !== null) {
+                    $action = $this->onDuplicate->resolveSchemaAction(
+                        true,
+                        $file->getUpdatedAt(),
+                        $existingFile->updatedAt,
+                    );
 
-                if ($existingFile !== null && $this->onDuplicate === OnDuplicate::Overwrite) {
-                    $this->storage->deleteFile($bucketId, $fileId);
+                    if ($action === SchemaAction::Skip) {
+                        $this->skippedChunkedUploads['file:' . $fileId] = true;
+                        $file->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
+                        $file->setData('');
+                        return $file;
+                    }
+
+                    if ($action === SchemaAction::Overwrite) {
+                        $this->storage->deleteFile($bucketId, $fileId);
+                    }
                 }
             } elseif (isset($this->skippedChunkedUploads['file:' . $fileId])) {
                 $file->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
@@ -2800,19 +2808,27 @@ class Appwrite extends Destination
                 fn () => $this->functions->getDeployment($functionId, $deploymentId)
             );
 
-            if ($existingDeployment !== null && $this->onDuplicate === OnDuplicate::Skip) {
-                $this->skippedChunkedUploads['deployment:' . $deploymentId] = true;
-                $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
-                $deployment->setData('');
-                return $deployment;
-            }
+            if ($existingDeployment !== null) {
+                $action = $this->onDuplicate->resolveSchemaAction(
+                    true,
+                    $deployment->getUpdatedAt(),
+                    $existingDeployment->updatedAt,
+                );
 
-            if ($existingDeployment !== null && $this->onDuplicate === OnDuplicate::Overwrite) {
-                try {
-                    $this->functions->deleteDeployment($functionId, $deploymentId);
-                } catch (AppwriteException $e) {
-                    if ($this->getSdkResourceOrNull(fn () => $this->functions->getDeployment($functionId, $deploymentId)) !== null) {
-                        throw $e;
+                if ($action === SchemaAction::Skip) {
+                    $this->skippedChunkedUploads['deployment:' . $deploymentId] = true;
+                    $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
+                    $deployment->setData('');
+                    return $deployment;
+                }
+
+                if ($action === SchemaAction::Overwrite) {
+                    try {
+                        $this->functions->deleteDeployment($functionId, $deploymentId);
+                    } catch (AppwriteException $e) {
+                        if ($this->getSdkResourceOrNull(fn () => $this->functions->getDeployment($functionId, $deploymentId)) !== null) {
+                            throw $e;
+                        }
                     }
                 }
             }
@@ -3698,19 +3714,27 @@ class Appwrite extends Destination
                 fn () => $this->sites->getDeployment($siteId, $deploymentId)
             );
 
-            if ($existingDeployment !== null && $this->onDuplicate === OnDuplicate::Skip) {
-                $this->skippedChunkedUploads['site-deployment:' . $deploymentId] = true;
-                $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
-                $deployment->setData('');
-                return $deployment;
-            }
+            if ($existingDeployment !== null) {
+                $action = $this->onDuplicate->resolveSchemaAction(
+                    true,
+                    $deployment->getUpdatedAt(),
+                    $existingDeployment->updatedAt,
+                );
 
-            if ($existingDeployment !== null && $this->onDuplicate === OnDuplicate::Overwrite) {
-                try {
-                    $this->sites->deleteDeployment($siteId, $deploymentId);
-                } catch (AppwriteException $e) {
-                    if ($this->getSdkResourceOrNull(fn () => $this->sites->getDeployment($siteId, $deploymentId)) !== null) {
-                        throw $e;
+                if ($action === SchemaAction::Skip) {
+                    $this->skippedChunkedUploads['site-deployment:' . $deploymentId] = true;
+                    $deployment->setStatus(Resource::STATUS_SKIPPED, 'Already exists on destination');
+                    $deployment->setData('');
+                    return $deployment;
+                }
+
+                if ($action === SchemaAction::Overwrite) {
+                    try {
+                        $this->sites->deleteDeployment($siteId, $deploymentId);
+                    } catch (AppwriteException $e) {
+                        if ($this->getSdkResourceOrNull(fn () => $this->sites->getDeployment($siteId, $deploymentId)) !== null) {
+                            throw $e;
+                        }
                     }
                 }
             }

--- a/src/Migration/Resources/Auth/Membership.php
+++ b/src/Migration/Resources/Auth/Membership.php
@@ -22,9 +22,13 @@ class Membership extends Resource
         private readonly Team  $team,
         private readonly User  $user,
         private readonly array $roles = [],
-        private readonly bool  $active = true
+        private readonly bool  $active = true,
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -38,7 +42,9 @@ class Membership extends Resource
             Team::fromArray($array['team'] ?? []),
             User::fromArray($array['user'] ?? []),
             $array['roles'] ?? [],
-            $array['active'] ?? true
+            $array['active'] ?? true,
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -53,6 +59,8 @@ class Membership extends Resource
             'user' => $this->user,
             'roles' => $this->roles,
             'active' => $this->active,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Auth/Team.php
+++ b/src/Migration/Resources/Auth/Team.php
@@ -17,9 +17,13 @@ class Team extends Resource
         string $id,
         private readonly string $name,
         private readonly array $preferences = [],
-        private readonly array $members = []
+        private readonly array $members = [],
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -32,7 +36,9 @@ class Team extends Resource
             $array['id'],
             $array['name'],
             $array['preferences'] ?? [],
-            $array['members'] ?? []
+            $array['members'] ?? [],
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -46,6 +52,8 @@ class Team extends Resource
             'name' => $this->name,
             'preferences' => $this->preferences,
             'members' => $this->members,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Auth/User.php
+++ b/src/Migration/Resources/Auth/User.php
@@ -34,8 +34,12 @@ class User extends Resource
         private readonly bool $disabled = false,
         private readonly array $preferences = [],
         private readonly array $targets = [],
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -57,6 +61,8 @@ class User extends Resource
             $array['disabled'] ?? false,
             $array['preferences'] ?? [],
             $array['targets'] ?? [],
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -78,6 +84,8 @@ class User extends Resource
             'disabled' => $this->disabled,
             'preferences' => $this->preferences,
             'targets' => $this->targets,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Backups/Policy.php
+++ b/src/Migration/Resources/Backups/Policy.php
@@ -26,12 +26,8 @@ class Policy extends Resource
         private readonly bool $enabled = true,
         private readonly string $resourceId = '',
         private readonly string $resourceType = '',
-        string $createdAt = '',
-        string $updatedAt = '',
     ) {
         $this->id = $id;
-        $this->createdAt = $createdAt;
-        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -49,8 +45,6 @@ class Policy extends Resource
             $array['enabled'] ?? true,
             $array['resourceId'] ?? '',
             $array['resourceType'] ?? '',
-            createdAt: $array['createdAt'] ?? '',
-            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -68,8 +62,6 @@ class Policy extends Resource
             'enabled' => $this->enabled,
             'resourceId' => $this->resourceId,
             'resourceType' => $this->resourceType,
-            'createdAt' => $this->createdAt,
-            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Backups/Policy.php
+++ b/src/Migration/Resources/Backups/Policy.php
@@ -26,8 +26,12 @@ class Policy extends Resource
         private readonly bool $enabled = true,
         private readonly string $resourceId = '',
         private readonly string $resourceType = '',
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -45,6 +49,8 @@ class Policy extends Resource
             $array['enabled'] ?? true,
             $array['resourceId'] ?? '',
             $array['resourceType'] ?? '',
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -62,6 +68,8 @@ class Policy extends Resource
             'enabled' => $this->enabled,
             'resourceId' => $this->resourceId,
             'resourceType' => $this->resourceType,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Functions/Deployment.php
+++ b/src/Migration/Resources/Functions/Deployment.php
@@ -15,9 +15,13 @@ class Deployment extends Resource
         private int $start = 0,
         private int $end = 0,
         private string $data = '',
-        private readonly bool $activated = false
+        private readonly bool $activated = false,
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -34,7 +38,9 @@ class Deployment extends Resource
             $array['start'] ?? 0,
             $array['end'] ?? 0,
             $array['data'] ?? '',
-            $array['activated'] ?? false
+            $array['activated'] ?? false,
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -52,6 +58,8 @@ class Deployment extends Resource
             'end' => $this->end,
             'data' => $this->data,
             'activated' => $this->activated,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Functions/EnvVar.php
+++ b/src/Migration/Resources/Functions/EnvVar.php
@@ -11,9 +11,13 @@ class EnvVar extends Resource
         string $id,
         private readonly Func $func,
         private readonly string $key,
-        private readonly string $value
+        private readonly string $value,
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -26,7 +30,9 @@ class EnvVar extends Resource
             $array['id'],
             Func::fromArray($array['func']),
             $array['key'],
-            $array['value']
+            $array['value'],
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -40,6 +46,8 @@ class EnvVar extends Resource
             'func' => $this->func,
             'key' => $this->key,
             'value' => $this->value,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Functions/Func.php
+++ b/src/Migration/Resources/Functions/Func.php
@@ -37,9 +37,13 @@ class Func extends Resource
         private readonly string $commands = '',
         private readonly bool $logging = true,
         private readonly array $scopes = [],
-        private readonly string $specification = ''
+        private readonly string $specification = '',
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -62,7 +66,9 @@ class Func extends Resource
             $array['commands'] ?? '',
             $array['logging'] ?? true,
             $array['scopes'] ?? [],
-            $array['specification'] ?? ''
+            $array['specification'] ?? '',
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -86,6 +92,8 @@ class Func extends Resource
             'logging' => $this->logging,
             'scopes' => $this->scopes,
             'specification' => $this->specification,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Sites/Deployment.php
+++ b/src/Migration/Resources/Sites/Deployment.php
@@ -14,9 +14,13 @@ class Deployment extends Resource
         private int $start = 0,
         private int $end = 0,
         private string $data = '',
-        private readonly bool $activated = false
+        private readonly bool $activated = false,
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -32,7 +36,9 @@ class Deployment extends Resource
             $array['start'] ?? 0,
             $array['end'] ?? 0,
             $array['data'] ?? '',
-            $array['activated'] ?? false
+            $array['activated'] ?? false,
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -49,6 +55,8 @@ class Deployment extends Resource
             'end' => $this->end,
             'data' => $this->data,
             'activated' => $this->activated,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Sites/EnvVar.php
+++ b/src/Migration/Resources/Sites/EnvVar.php
@@ -11,9 +11,13 @@ class EnvVar extends Resource
         string $id,
         private readonly Site $site,
         private readonly string $key,
-        private readonly string $value
+        private readonly string $value,
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -26,7 +30,9 @@ class EnvVar extends Resource
             $array['id'],
             Site::fromArray($array['site']),
             $array['key'],
-            $array['value']
+            $array['value'],
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -40,6 +46,8 @@ class EnvVar extends Resource
             'site' => $this->site,
             'key' => $this->key,
             'value' => $this->value,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Sites/Site.php
+++ b/src/Migration/Resources/Sites/Site.php
@@ -37,9 +37,13 @@ class Site extends Resource
         private readonly string $adapter = 'static',
         private readonly string $fallbackFile = '',
         private readonly string $specification = '',
-        private readonly string $activeDeployment = ''
+        private readonly string $activeDeployment = '',
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -62,7 +66,9 @@ class Site extends Resource
             $array['adapter'] ?? 'static',
             $array['fallbackFile'] ?? '',
             $array['specification'] ?? '',
-            $array['activeDeployment'] ?? ''
+            $array['activeDeployment'] ?? '',
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -86,6 +92,8 @@ class Site extends Resource
             'fallbackFile' => $this->fallbackFile,
             'specification' => $this->specification,
             'activeDeployment' => $this->activeDeployment,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Storage/Bucket.php
+++ b/src/Migration/Resources/Storage/Bucket.php
@@ -34,9 +34,13 @@ class Bucket extends Resource
         private readonly bool $antiVirus = false,
         private readonly bool $updateLimits = false,
         private readonly bool $transformations = false,
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
         $this->permissions = $permissions;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -57,7 +61,9 @@ class Bucket extends Resource
             $array['encryption'] ?? false,
             $array['antiVirus'] ?? false,
             $array['updateLimits'] ?? false,
-            $array['transformations'] ?? false
+            $array['transformations'] ?? false,
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -78,6 +84,8 @@ class Bucket extends Resource
             'antiVirus' => $this->antiVirus,
             'updateLimits' => $this->updateLimits,
             'transformations' => $this->transformations,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Resources/Storage/File.php
+++ b/src/Migration/Resources/Storage/File.php
@@ -29,10 +29,14 @@ class File extends Resource
         private readonly int $size = 0,
         private string $data = '',
         private int $start = 0,
-        private int $end = 0
+        private int $end = 0,
+        string $createdAt = '',
+        string $updatedAt = '',
     ) {
         $this->id = $id;
         $this->permissions = $permissions;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
     }
 
     /**
@@ -51,7 +55,9 @@ class File extends Resource
             $array['size'] ?? 0,
             $array['data'] ?? '',
             $array['start'] ?? 0,
-            $array['end'] ?? 0
+            $array['end'] ?? 0,
+            createdAt: $array['createdAt'] ?? '',
+            updatedAt: $array['updatedAt'] ?? '',
         );
     }
 
@@ -70,6 +76,8 @@ class File extends Resource
             'size' => $this->size,
             'start' => $this->start,
             'end' => $this->end,
+            'createdAt' => $this->createdAt,
+            'updatedAt' => $this->updatedAt,
         ];
     }
 

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -1598,7 +1598,7 @@ class Appwrite extends Source
             $chunkData = $this->call(
                 'GET',
                 "/storage/buckets/{$file->getBucket()->getId()}/files/{$file->getId()}/download",
-                ['range' => "bytes=$start-$end"]
+                ['Range' => "bytes=$start-$end"]
             );
 
             // Send the chunk to the callback function
@@ -2268,6 +2268,25 @@ class Appwrite extends Source
             $responseHeaders
         );
 
+        $firstChunkData = null;
+        if (!\array_key_exists('content-length', $responseHeaders)) {
+            $probeHeaders = [];
+            $firstChunkData = $this->call(
+                'GET',
+                "/functions/{$func->getId()}/deployments/{$deployment->id}/download",
+                ['Range' => "bytes=$start-"],
+                [],
+                $probeHeaders
+            );
+
+            if (
+                isset($probeHeaders['content-range'])
+                && \preg_match('/\/(\d+)$/', $probeHeaders['content-range'], $matches) === 1
+            ) {
+                $responseHeaders['content-length'] = $matches[1];
+            }
+        }
+
         // content-length header missing, file is less than max buffer size
         if (!array_key_exists('content-length', $responseHeaders)) {
             $file = $this->call(
@@ -2326,11 +2345,12 @@ class Appwrite extends Source
 
         // Loop until the entire file is downloaded
         while ($start < $fileSize) {
-            $chunkData = $this->call(
+            $chunkData = $firstChunkData ?? $this->call(
                 'GET',
                 "/functions/{$func->getId()}/deployments/{$deployment->getSequence()}/download",
-                ['range' => "bytes=$start-$end"]
+                ['Range' => "bytes=$start-$end"]
             );
+            $firstChunkData = null;
 
             // Send the chunk to the callback function
             $deployment
@@ -2861,6 +2881,25 @@ class Appwrite extends Source
             $responseHeaders
         );
 
+        $firstChunkData = null;
+        if (!\array_key_exists('content-length', $responseHeaders)) {
+            $probeHeaders = [];
+            $firstChunkData = $this->call(
+                'GET',
+                "/sites/{$site->getId()}/deployments/{$deployment->id}/download",
+                ['Range' => "bytes=$start-"],
+                [],
+                $probeHeaders
+            );
+
+            if (
+                isset($probeHeaders['content-range'])
+                && \preg_match('/\/(\d+)$/', $probeHeaders['content-range'], $matches) === 1
+            ) {
+                $responseHeaders['content-length'] = $matches[1];
+            }
+        }
+
         if (!\array_key_exists('content-length', $responseHeaders)) {
             $file = $this->call(
                 'GET',
@@ -2915,11 +2954,12 @@ class Appwrite extends Source
         $siteDeployment->setSequence($siteDeployment->getId());
 
         while ($start < $fileSize) {
-            $chunkData = $this->call(
+            $chunkData = $firstChunkData ?? $this->call(
                 'GET',
                 "/sites/{$site->getId()}/deployments/{$siteDeployment->getSequence()}/download",
-                ['range' => "bytes=$start-$end"]
+                ['Range' => "bytes=$start-$end"]
             );
+            $firstChunkData = null;
 
             $siteDeployment
                 ->setData($chunkData)

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -2145,6 +2145,8 @@ class Appwrite extends Source
             $convertedResources = [];
 
             foreach ($response->functions as $function) {
+                $activeDeployment = $function->deploymentId ?? $function->deployment ?? '';
+
                 $convertedFunc = new Func(
                     $function->id,
                     $function->name,
@@ -2154,7 +2156,7 @@ class Appwrite extends Source
                     $function->events,
                     $function->schedule,
                     $function->timeout,
-                    $function->deploymentId ?? '',
+                    $activeDeployment,
                     $function->entrypoint,
                     $function->commands ?? '',
                     $function->logging ?? true,
@@ -2737,6 +2739,8 @@ class Appwrite extends Source
             $convertedResources = [];
 
             foreach ($response->sites as $site) {
+                $activeDeployment = $site->deploymentId ?? $site->deployment ?? '';
+
                 $convertedSite = new Site(
                     $site->id,
                     $site->name,
@@ -2751,7 +2755,7 @@ class Appwrite extends Source
                     $site->adapter ?? 'static',
                     $site->fallbackFile ?? '',
                     $site->runtimeSpecification ?: $site->buildSpecification ?: '',
-                    $site->deploymentId ?? '',
+                    $activeDeployment,
                     createdAt: $site->createdAt,
                     updatedAt: $site->updatedAt,
                 );

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -829,6 +829,8 @@ class Appwrite extends Source
                     !$user->status,
                     $user->prefs->data ?? [],
                     \array_map(fn ($target) => $target->toArray(), $user->targets ?? []),
+                    createdAt: $user->createdAt,
+                    updatedAt: $user->updatedAt,
                 );
 
                 $lastDocument = $user->id;
@@ -874,6 +876,8 @@ class Appwrite extends Source
                     $team->id,
                     $team->name,
                     $team->prefs->data,
+                    createdAt: $team->createdAt,
+                    updatedAt: $team->updatedAt,
                 );
 
                 $lastDocument = $team->id;
@@ -932,7 +936,9 @@ class Appwrite extends Source
                         $team,
                         $user,
                         $membership->roles,
-                        $membership->confirm
+                        $membership->confirm,
+                        createdAt: $membership->createdAt ?? '',
+                        updatedAt: $membership->updatedAt ?? '',
                     );
 
                     $lastDocument = $membership->id;
@@ -1467,6 +1473,8 @@ class Appwrite extends Source
                 $bucket->antivirus,
                 false,
                 $bucket->transformations ?? false,
+                createdAt: $bucket->createdAt,
+                updatedAt: $bucket->updatedAt,
             );
             $convertedBuckets[] = $bucket;
         }
@@ -1511,6 +1519,8 @@ class Appwrite extends Source
                             $file->mimeType,
                             $file->permissions,
                             $file->sizeOriginal,
+                            createdAt: $file->createdAt,
+                            updatedAt: $file->updatedAt,
                         ));
                     } catch (\Throwable $e) {
                         $this->addError(new Exception(
@@ -2107,6 +2117,8 @@ class Appwrite extends Source
                     $function->logging ?? true,
                     $function->scopes ?? [],
                     $function->runtimeSpecification ?: $function->buildSpecification ?: '',
+                    createdAt: $function->createdAt,
+                    updatedAt: $function->updatedAt,
                 );
                 $functions[] = $convertedFunc;
 
@@ -2118,6 +2130,8 @@ class Appwrite extends Source
                         $convertedFunc,
                         $var->key,
                         $var->value,
+                        createdAt: $var->createdAt,
+                        updatedAt: $var->updatedAt,
                     );
                 }
             }
@@ -2233,7 +2247,9 @@ class Appwrite extends Source
                 $start,
                 $end,
                 $file,
-                $deployment->activate
+                $deployment->activate,
+                createdAt: $deployment->createdAt,
+                updatedAt: $deployment->updatedAt,
             );
             $deployment->setSequence($deployment->getId());
 
@@ -2256,7 +2272,9 @@ class Appwrite extends Source
             $start,
             $end,
             '',
-            $deployment->activate
+            $deployment->activate,
+            createdAt: $deployment->createdAt,
+            updatedAt: $deployment->updatedAt,
         );
 
         $deployment->setSequence($deployment->getId());
@@ -2658,7 +2676,9 @@ class Appwrite extends Source
                     $site->adapter ?? 'static',
                     $site->fallbackFile ?? '',
                     $site->runtimeSpecification ?: $site->buildSpecification ?: '',
-                    $site->deploymentId ?? ''
+                    $site->deploymentId ?? '',
+                    createdAt: $site->createdAt,
+                    updatedAt: $site->updatedAt,
                 );
                 $sites[] = $convertedSite;
                 $convertedResources[] = $convertedSite;
@@ -2669,7 +2689,9 @@ class Appwrite extends Source
                         $var->id,
                         $convertedSite,
                         $var->key,
-                        $var->value
+                        $var->value,
+                        createdAt: $var->createdAt,
+                        updatedAt: $var->updatedAt,
                     );
                 }
             }
@@ -2782,7 +2804,9 @@ class Appwrite extends Source
                 $start,
                 $end,
                 $file,
-                $deployment->id === $site->getActiveDeployment()
+                $deployment->id === $site->getActiveDeployment(),
+                createdAt: $deployment->createdAt,
+                updatedAt: $deployment->updatedAt,
             );
             $siteDeployment->setSequence($siteDeployment->getId());
 
@@ -2804,7 +2828,9 @@ class Appwrite extends Source
             $start,
             $end,
             '',
-            $deployment->id === $site->getActiveDeployment()
+            $deployment->id === $site->getActiveDeployment(),
+            createdAt: $deployment->createdAt,
+            updatedAt: $deployment->updatedAt,
         );
 
         $siteDeployment->setSequence($siteDeployment->getId());


### PR DESCRIPTION
## Summary
- add Appwrite duplicate handling modes for skip and overwrite across imported resources
- carry createdAt and updatedAt through Appwrite source resources so overwrite only updates when the source is newer
- preserve fail-mode create behavior as the default path
- overwrite SDK-backed resources in place where supported, match natural-key resources such as memberships/platforms/rules, and replace existing files by deleting only the matching destination file ID before re-upload
- keep deployment overwrite conservative: existing function/site deployments are skipped instead of deleted and recreated

## Validation
- composer format
- composer lint
- composer check
- live source-to-destination fail-mode migration
- live skip-mode migration with source-only resources and existing destination conflicts
- live overwrite-mode migration with matching resources, source-only resources, and destination-only sentinels
- live file overwrite check confirmed matching file content is replaced, source-only file is created, and unrelated destination file is preserved

## Review Notes
- overwrite only applies when the source updatedAt is newer than destination updatedAt; otherwise the resource is skipped
- file overwrite deletes only the matching file ID in the matching bucket, then reuses the existing upload path
- deployment overwrite remains skipped because safely replacing deployment artifacts needs a separate delete-and-reupload recovery path
