### PR TITLE
fix: guard Appwrite source reportSites/reportMessaging against source failures

### DIFF
--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -539,34 +539,43 @@ class Appwrite extends Source
         $totalSites = 0;
 
         if (!$needVarsOrDeployments && \in_array(Resource::TYPE_SITE, $resources)) {
-            $siteQueries = $this->buildQueries(
-                resourceType: Resource::TYPE_SITE,
-                resourceIds: $resourceIds,
-                limit: 1
-            );
-            $report[Resource::TYPE_SITE] = $this->sites->list($siteQueries)->total;
+            try {
+                $siteQueries = $this->buildQueries(
+                    resourceType: Resource::TYPE_SITE,
+                    resourceIds: $resourceIds,
+                    limit: 1
+                );
+                $report[Resource::TYPE_SITE] = $this->sites->list($siteQueries)->total;
+            } catch (\Throwable) {
+                $report[Resource::TYPE_SITE] = 0;
+            }
             return;
         }
 
         if ($needVarsOrDeployments) {
-            $lastSite = null;
-            while (true) {
-                $params = $this->buildQueries(
-                    resourceType: Resource::TYPE_SITE,
-                    resourceIds: $resourceIds,
-                    cursor: $lastSite,
-                );
-                $siteList = $this->sites->list($params);
+            try {
+                $lastSite = null;
+                while (true) {
+                    $params = $this->buildQueries(
+                        resourceType: Resource::TYPE_SITE,
+                        resourceIds: $resourceIds,
+                        cursor: $lastSite,
+                    );
+                    $siteList = $this->sites->list($params);
 
-                $totalSites = $siteList->total;
-                $currentSites = $siteList->sites;
-                $sites = array_merge($sites, $currentSites);
+                    $totalSites = $siteList->total;
+                    $currentSites = $siteList->sites;
+                    $sites = array_merge($sites, $currentSites);
 
-                if (count($currentSites) === 0 || count($currentSites) < self::DEFAULT_PAGE_LIMIT) {
-                    break;
+                    if (count($currentSites) === 0 || count($currentSites) < self::DEFAULT_PAGE_LIMIT) {
+                        break;
+                    }
+
+                    $lastSite = $currentSites[count($currentSites) - 1]->id;
                 }
-
-                $lastSite = $currentSites[count($currentSites) - 1]->id;
+            } catch (\Throwable) {
+                $sites = [];
+                $totalSites = 0;
             }
         }
 
@@ -585,9 +594,13 @@ class Appwrite extends Source
 
         if (\in_array(Resource::TYPE_SITE_VARIABLE, $resources)) {
             $report[Resource::TYPE_SITE_VARIABLE] = 0;
-            foreach ($sites as $site) {
-                $variables = $this->sites->listVariables($site->id);
-                $report[Resource::TYPE_SITE_VARIABLE] += $variables->total ?? 0;
+            try {
+                foreach ($sites as $site) {
+                    $variables = $this->sites->listVariables($site->id);
+                    $report[Resource::TYPE_SITE_VARIABLE] += $variables->total ?? 0;
+                }
+            } catch (\Throwable) {
+                // Leave partially-accumulated count; source lacks Sites support or scope.
             }
         }
     }
@@ -2296,58 +2309,75 @@ class Appwrite extends Source
     private function reportMessaging(array $resources, array &$report, array $resourceIds = []): void
     {
         if (\in_array(Resource::TYPE_PROVIDER, $resources)) {
-            $providerQueries = $this->buildQueries(
-                resourceType: Resource::TYPE_PROVIDER,
-                resourceIds: $resourceIds,
-                limit: 1
-            );
-            $report[Resource::TYPE_PROVIDER] = $this->messaging->listProviders($providerQueries)->total;
+            try {
+                $providerQueries = $this->buildQueries(
+                    resourceType: Resource::TYPE_PROVIDER,
+                    resourceIds: $resourceIds,
+                    limit: 1
+                );
+                $report[Resource::TYPE_PROVIDER] = $this->messaging->listProviders($providerQueries)->total;
+            } catch (\Throwable) {
+                $report[Resource::TYPE_PROVIDER] = 0;
+            }
         }
 
         if (\in_array(Resource::TYPE_TOPIC, $resources)) {
-            $topicQueries = $this->buildQueries(
-                resourceType: Resource::TYPE_TOPIC,
-                resourceIds: $resourceIds,
-                limit: 1
-            );
-            $report[Resource::TYPE_TOPIC] = $this->messaging->listTopics($topicQueries)->total;
+            try {
+                $topicQueries = $this->buildQueries(
+                    resourceType: Resource::TYPE_TOPIC,
+                    resourceIds: $resourceIds,
+                    limit: 1
+                );
+                $report[Resource::TYPE_TOPIC] = $this->messaging->listTopics($topicQueries)->total;
+            } catch (\Throwable) {
+                $report[Resource::TYPE_TOPIC] = 0;
+            }
         }
 
         if (\in_array(Resource::TYPE_SUBSCRIBER, $resources)) {
             $subscriberTotal = 0;
-            $lastTopic = null;
 
-            while (true) {
-                $topicQueries = [Query::limit(self::DEFAULT_PAGE_LIMIT)];
-                if ($lastTopic) {
-                    $topicQueries[] = Query::cursorAfter($lastTopic);
-                }
+            try {
+                $lastTopic = null;
 
-                $topicResponse = $this->messaging->listTopics($topicQueries);
-                if ($topicResponse->total == 0 || empty($topicResponse->topics)) {
-                    break;
-                }
+                while (true) {
+                    $topicQueries = [Query::limit(self::DEFAULT_PAGE_LIMIT)];
+                    if ($lastTopic) {
+                        $topicQueries[] = Query::cursorAfter($lastTopic);
+                    }
 
-                foreach ($topicResponse->topics as $topic) {
-                    $subscriberTotal += $this->messaging->listSubscribers($topic->id, [Query::limit(1)])->total;
-                    $lastTopic = $topic->id;
-                }
+                    $topicResponse = $this->messaging->listTopics($topicQueries);
+                    if ($topicResponse->total == 0 || empty($topicResponse->topics)) {
+                        break;
+                    }
 
-                if (\count($topicResponse->topics) < self::DEFAULT_PAGE_LIMIT) {
-                    break;
+                    foreach ($topicResponse->topics as $topic) {
+                        $subscriberTotal += $this->messaging->listSubscribers($topic->id, [Query::limit(1)])->total;
+                        $lastTopic = $topic->id;
+                    }
+
+                    if (\count($topicResponse->topics) < self::DEFAULT_PAGE_LIMIT) {
+                        break;
+                    }
                 }
+            } catch (\Throwable) {
+                $subscriberTotal = 0;
             }
 
             $report[Resource::TYPE_SUBSCRIBER] = $subscriberTotal;
         }
 
         if (\in_array(Resource::TYPE_MESSAGE, $resources)) {
-            $messageQueries = $this->buildQueries(
-                resourceType: Resource::TYPE_MESSAGE,
-                resourceIds: $resourceIds,
-                limit: 1
-            );
-            $report[Resource::TYPE_MESSAGE] = $this->messaging->listMessages($messageQueries)->total;
+            try {
+                $messageQueries = $this->buildQueries(
+                    resourceType: Resource::TYPE_MESSAGE,
+                    resourceIds: $resourceIds,
+                    limit: 1
+                );
+                $report[Resource::TYPE_MESSAGE] = $this->messaging->listMessages($messageQueries)->total;
+            } catch (\Throwable) {
+                $report[Resource::TYPE_MESSAGE] = 0;
+            }
         }
     }
 

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -263,13 +263,6 @@ class Appwrite extends Source
         };
     }
 
-    private function isAppwriteServerError(\Throwable $e): bool
-    {
-        return $e instanceof AppwriteException
-            && $e->getCode() >= 500
-            && $e->getCode() < 600;
-    }
-
     /**
      * @param array<string> $resources
      * @param array<string, array<string>> $resourceIds
@@ -554,11 +547,11 @@ class Appwrite extends Source
                 );
                 $report[Resource::TYPE_SITE] = $this->sites->list($siteQueries)->total;
             } catch (\Throwable $e) {
-                if (!$this->isAppwriteServerError($e)) {
+                if ($e->getCode() >= 500 && $e->getCode() < 600) {
+                    $report[Resource::TYPE_SITE] = 0;
+                } else {
                     throw $e;
                 }
-
-                $report[Resource::TYPE_SITE] = 0;
             }
             return;
         }
@@ -585,12 +578,12 @@ class Appwrite extends Source
                     $lastSite = $currentSites[count($currentSites) - 1]->id;
                 }
             } catch (\Throwable $e) {
-                if (!$this->isAppwriteServerError($e)) {
+                if ($e->getCode() >= 500 && $e->getCode() < 600) {
+                    $sites = [];
+                    $totalSites = 0;
+                } else {
                     throw $e;
                 }
-
-                $sites = [];
-                $totalSites = 0;
             }
         }
 
@@ -615,11 +608,11 @@ class Appwrite extends Source
                     $report[Resource::TYPE_SITE_VARIABLE] += $variables->total ?? 0;
                 }
             } catch (\Throwable $e) {
-                if (!$this->isAppwriteServerError($e)) {
+                if ($e->getCode() >= 500 && $e->getCode() < 600) {
+                    $report[Resource::TYPE_SITE_VARIABLE] = 0;
+                } else {
                     throw $e;
                 }
-
-                $report[Resource::TYPE_SITE_VARIABLE] = 0;
             }
         }
     }
@@ -1684,11 +1677,11 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_RULE] = $this->proxy->listRules([Query::limit(1)])->total;
             } catch (\Throwable $e) {
-                if (!$this->isAppwriteServerError($e)) {
+                if ($e->getCode() >= 500 && $e->getCode() < 600) {
+                    $report[Resource::TYPE_RULE] = 0;
+                } else {
                     throw $e;
                 }
-
-                $report[Resource::TYPE_RULE] = 0;
             }
         }
     }
@@ -1704,11 +1697,11 @@ class Appwrite extends Source
             try {
                 $report[Resource::TYPE_PROJECT_VARIABLE] = $this->project->listVariables($variableQueries)->total;
             } catch (\Throwable $e) {
-                if (!$this->isAppwriteServerError($e)) {
+                if ($e->getCode() >= 500 && $e->getCode() < 600) {
+                    $report[Resource::TYPE_PROJECT_VARIABLE] = 0;
+                } else {
                     throw $e;
                 }
-
-                $report[Resource::TYPE_PROJECT_VARIABLE] = 0;
             }
         }
 
@@ -2343,11 +2336,11 @@ class Appwrite extends Source
                 );
                 $report[Resource::TYPE_PROVIDER] = $this->messaging->listProviders($providerQueries)->total;
             } catch (\Throwable $e) {
-                if (!$this->isAppwriteServerError($e)) {
+                if ($e->getCode() >= 500 && $e->getCode() < 600) {
+                    $report[Resource::TYPE_PROVIDER] = 0;
+                } else {
                     throw $e;
                 }
-
-                $report[Resource::TYPE_PROVIDER] = 0;
             }
         }
 
@@ -2360,11 +2353,11 @@ class Appwrite extends Source
                 );
                 $report[Resource::TYPE_TOPIC] = $this->messaging->listTopics($topicQueries)->total;
             } catch (\Throwable $e) {
-                if (!$this->isAppwriteServerError($e)) {
+                if ($e->getCode() >= 500 && $e->getCode() < 600) {
+                    $report[Resource::TYPE_TOPIC] = 0;
+                } else {
                     throw $e;
                 }
-
-                $report[Resource::TYPE_TOPIC] = 0;
             }
         }
 
@@ -2395,11 +2388,11 @@ class Appwrite extends Source
                     }
                 }
             } catch (\Throwable $e) {
-                if (!$this->isAppwriteServerError($e)) {
+                if ($e->getCode() >= 500 && $e->getCode() < 600) {
+                    $subscriberTotal = 0;
+                } else {
                     throw $e;
                 }
-
-                $subscriberTotal = 0;
             }
 
             $report[Resource::TYPE_SUBSCRIBER] = $subscriberTotal;
@@ -2414,11 +2407,11 @@ class Appwrite extends Source
                 );
                 $report[Resource::TYPE_MESSAGE] = $this->messaging->listMessages($messageQueries)->total;
             } catch (\Throwable $e) {
-                if (!$this->isAppwriteServerError($e)) {
+                if ($e->getCode() >= 500 && $e->getCode() < 600) {
+                    $report[Resource::TYPE_MESSAGE] = 0;
+                } else {
                     throw $e;
                 }
-
-                $report[Resource::TYPE_MESSAGE] = 0;
             }
         }
     }

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -263,6 +263,13 @@ class Appwrite extends Source
         };
     }
 
+    private function isAppwriteServerError(\Throwable $e): bool
+    {
+        return $e instanceof AppwriteException
+            && $e->getCode() >= 500
+            && $e->getCode() < 600;
+    }
+
     /**
      * @param array<string> $resources
      * @param array<string, array<string>> $resourceIds
@@ -546,7 +553,11 @@ class Appwrite extends Source
                     limit: 1
                 );
                 $report[Resource::TYPE_SITE] = $this->sites->list($siteQueries)->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                if (!$this->isAppwriteServerError($e)) {
+                    throw $e;
+                }
+
                 $report[Resource::TYPE_SITE] = 0;
             }
             return;
@@ -573,7 +584,11 @@ class Appwrite extends Source
 
                     $lastSite = $currentSites[count($currentSites) - 1]->id;
                 }
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                if (!$this->isAppwriteServerError($e)) {
+                    throw $e;
+                }
+
                 $sites = [];
                 $totalSites = 0;
             }
@@ -599,7 +614,11 @@ class Appwrite extends Source
                     $variables = $this->sites->listVariables($site->id);
                     $report[Resource::TYPE_SITE_VARIABLE] += $variables->total ?? 0;
                 }
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                if (!$this->isAppwriteServerError($e)) {
+                    throw $e;
+                }
+
                 $report[Resource::TYPE_SITE_VARIABLE] = 0;
             }
         }
@@ -1664,7 +1683,11 @@ class Appwrite extends Source
         if (\in_array(Resource::TYPE_RULE, $resources)) {
             try {
                 $report[Resource::TYPE_RULE] = $this->proxy->listRules([Query::limit(1)])->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                if (!$this->isAppwriteServerError($e)) {
+                    throw $e;
+                }
+
                 $report[Resource::TYPE_RULE] = 0;
             }
         }
@@ -1680,7 +1703,11 @@ class Appwrite extends Source
             );
             try {
                 $report[Resource::TYPE_PROJECT_VARIABLE] = $this->project->listVariables($variableQueries)->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                if (!$this->isAppwriteServerError($e)) {
+                    throw $e;
+                }
+
                 $report[Resource::TYPE_PROJECT_VARIABLE] = 0;
             }
         }
@@ -2315,7 +2342,11 @@ class Appwrite extends Source
                     limit: 1
                 );
                 $report[Resource::TYPE_PROVIDER] = $this->messaging->listProviders($providerQueries)->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                if (!$this->isAppwriteServerError($e)) {
+                    throw $e;
+                }
+
                 $report[Resource::TYPE_PROVIDER] = 0;
             }
         }
@@ -2328,7 +2359,11 @@ class Appwrite extends Source
                     limit: 1
                 );
                 $report[Resource::TYPE_TOPIC] = $this->messaging->listTopics($topicQueries)->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                if (!$this->isAppwriteServerError($e)) {
+                    throw $e;
+                }
+
                 $report[Resource::TYPE_TOPIC] = 0;
             }
         }
@@ -2359,7 +2394,11 @@ class Appwrite extends Source
                         break;
                     }
                 }
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                if (!$this->isAppwriteServerError($e)) {
+                    throw $e;
+                }
+
                 $subscriberTotal = 0;
             }
 
@@ -2374,7 +2413,11 @@ class Appwrite extends Source
                     limit: 1
                 );
                 $report[Resource::TYPE_MESSAGE] = $this->messaging->listMessages($messageQueries)->total;
-            } catch (\Throwable) {
+            } catch (\Throwable $e) {
+                if (!$this->isAppwriteServerError($e)) {
+                    throw $e;
+                }
+
                 $report[Resource::TYPE_MESSAGE] = 0;
             }
         }

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -600,7 +600,7 @@ class Appwrite extends Source
                     $report[Resource::TYPE_SITE_VARIABLE] += $variables->total ?? 0;
                 }
             } catch (\Throwable) {
-                // Leave partially-accumulated count; source lacks Sites support or scope.
+                $report[Resource::TYPE_SITE_VARIABLE] = 0;
             }
         }
     }
@@ -2304,7 +2304,6 @@ class Appwrite extends Source
      * @param array<string> $resources
      * @param array<string, int> $report
      * @param array<string, array<string>> $resourceIds
-     * @throws AppwriteException
      */
     private function reportMessaging(array $resources, array &$report, array $resourceIds = []): void
     {


### PR DESCRIPTION
## Summary
- `reportSites()` and `reportMessaging()` in `Sources\Appwrite` had no error handling around their API calls, unlike sibling methods (`reportDomains`, `reportProjects`) which already degrade to a `0` count when the source can't serve that resource.
- If the source project fails to serve Sites or Messaging data (missing API key scope, or an older self-hosted version that predates the feature), the exception propagated uncaught through `report()`, aborting the *entire* pre-flight report before any resource was counted or processed — even resources unrelated to Sites/Messaging.
- This surfaced as a generic "Migration failed due to an unexpected error" (500) with empty `resourceId`/`statusCounters`/`resourceData`, reported by a user migrating a self-hosted 1.9.5 Appwrite project to Cloud via the Console, where the resource list defaulted to including `site`/`site-deployment`/`site-variable`.

## Fix
Wrapped each resource-type branch in `reportSites()` and `reportMessaging()` in `try/catch (\Throwable)`, defaulting the count to `0` on failure — the same pattern already used in `reportDomains()` and `reportProjects()`.

## Test plan
- [x] Reproduced the original crash with a local stub server returning 404 on `/v1/sites` and 401 on `/v1/messaging/*`, confirmed `reportSites()`/`reportMessaging()` threw uncaught before the fix.
- [x] Re-ran the same reproduction against the patched methods — both now return gracefully with the affected resource counted as `0`, and `report()` no longer aborts.
- [x] `php -l` and `vendor/bin/pint --test` pass on the changed file.