### PR TITLE
Add appwrite OAuth2 provider to migration allow-list

### DIFF
--- a/src/Migration/Resources/Auth/OAuth2/OAuth2Provider.php
+++ b/src/Migration/Resources/Auth/OAuth2/OAuth2Provider.php
@@ -31,6 +31,7 @@ final class OAuth2Provider extends Resource
             'keyId' => ['target' => self::TARGET_SECRET, 'key' => 'keyID'],
             'teamId' => ['target' => self::TARGET_SECRET, 'key' => 'teamID'],
         ],
+        'appwrite' => ['clientId' => ['target' => self::TARGET_APP_ID]],
         'auth0' => ['clientId' => ['target' => self::TARGET_APP_ID], 'endpoint' => ['target' => self::TARGET_SECRET]],
         'authentik' => ['clientId' => ['target' => self::TARGET_APP_ID], 'endpoint' => ['target' => self::TARGET_SECRET]],
         'autodesk' => ['clientId' => ['target' => self::TARGET_APP_ID]],

--- a/tests/Migration/Unit/Resources/OAuth2ProviderTest.php
+++ b/tests/Migration/Unit/Resources/OAuth2ProviderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Utopia\Tests\Unit\Resources;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Migration\Resources\Auth\OAuth2\OAuth2Provider;
+
+class OAuth2ProviderTest extends TestCase
+{
+    public function testFromArrayAppwrite(): void
+    {
+        $provider = OAuth2Provider::fromArray('appwrite', [
+            'id' => 'appwrite',
+            'enabled' => true,
+            'clientId' => 'client-123',
+            'clientSecret' => 'super-secret',
+        ]);
+
+        $this->assertNotNull($provider);
+        $this->assertEquals('appwrite', $provider->getProviderKey());
+        $this->assertTrue($provider->getEnabled());
+        $this->assertEquals(['clientId' => 'client-123'], $provider->getSettings());
+        $this->assertEquals('client-123', $provider->getDestinationAppId());
+        $this->assertEquals([], $provider->getDestinationSecretFields());
+        $this->assertTrue($provider->isConfigured());
+    }
+
+    public function testFromArrayNeverCopiesSecrets(): void
+    {
+        foreach (\array_keys(OAuth2Provider::PROVIDERS) as $providerKey) {
+            $provider = OAuth2Provider::fromArray($providerKey, [
+                'id' => $providerKey,
+                'enabled' => false,
+                'clientId' => 'client-123',
+                'clientSecret' => 'super-secret',
+                'p8File' => 'p8-contents',
+            ]);
+
+            $this->assertNotNull($provider);
+            $this->assertArrayNotHasKey('clientSecret', $provider->getSettings(), $providerKey);
+            $this->assertArrayNotHasKey('p8File', $provider->getSettings(), $providerKey);
+        }
+    }
+
+    public function testFromArrayUnknownProvider(): void
+    {
+        $this->assertNull(OAuth2Provider::fromArray('unknown', [
+            'id' => 'unknown',
+            'enabled' => true,
+            'clientId' => 'client-123',
+        ]));
+    }
+}


### PR DESCRIPTION
## What
Adds the `appwrite` provider key (Appwrite-as-an-identity-provider, e.g. sign in with Appwrite Cloud) to the `OAuth2Provider::PROVIDERS` allow-list, inserted alphabetically between `apple` and `auth0`.

## Why
Appwrite server is adding a built-in `appwrite` OAuth2 provider. Migrations that include the `oauth2-provider` resource currently fail with:

> No migration resource for OAuth2 provider 'appwrite'; skipped.

## Details
- Only `clientId` migrates, targeting the destination's `appwriteAppid` project attribute — same shape as `github`/`discord`.
- `clientSecret` is write-only on the server and is never copied, consistent with the class's secret-redaction policy.
- The OAuth endpoint is hardcoded server-side (`https://cloud.appwrite.io/v1/oauth2/console`), so there is no endpoint/domain setting to carry over.
- No changes needed in `Sources/Appwrite.php` or `Destinations/Appwrite.php` — both are driven by the `PROVIDERS` descriptor.

## Tests
New `OAuth2ProviderTest` unit test covering `fromArray()` for the `appwrite` key, secret redaction across every provider in the allow-list, and unknown-provider handling.

A release should follow this merge so appwrite/appwrite can bump `utopia-php/migration` past 1.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)