### PR TITLE
Preserve build and runtime specifications

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2473,7 +2473,7 @@ class Appwrite extends Destination
                     entrypoint: $resource->getEntrypoint(),
                     commands: $resource->getCommands(),
                     scopes: $resource->getScopes(),
-                    buildSpecification: $resource->getSpecification() ?: null,
+                    buildSpecification: 's-2vcpu-2gb',
                     runtimeSpecification: $resource->getSpecification() ?: null,
                 );
                 break;
@@ -2662,7 +2662,7 @@ class Appwrite extends Destination
                     outputDirectory: $resource->getOutputDirectory(),
                     adapter: $adapter,
                     fallbackFile: $resource->getFallbackFile(),
-                    buildSpecification: $resource->getSpecification() ?: null,
+                    buildSpecification: 's-2vcpu-2gb',
                     runtimeSpecification: $resource->getSpecification() ?: null,
                 );
                 break;

--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -2473,8 +2473,8 @@ class Appwrite extends Destination
                     entrypoint: $resource->getEntrypoint(),
                     commands: $resource->getCommands(),
                     scopes: $resource->getScopes(),
-                    buildSpecification: 's-2vcpu-2gb',
-                    runtimeSpecification: $resource->getSpecification() ?: null,
+                    buildSpecification: $resource->getBuildSpecification() ?: null,
+                    runtimeSpecification: $resource->getRuntimeSpecification() ?: null,
                 );
                 break;
             case Resource::TYPE_ENVIRONMENT_VARIABLE:
@@ -2662,8 +2662,8 @@ class Appwrite extends Destination
                     outputDirectory: $resource->getOutputDirectory(),
                     adapter: $adapter,
                     fallbackFile: $resource->getFallbackFile(),
-                    buildSpecification: 's-2vcpu-2gb',
-                    runtimeSpecification: $resource->getSpecification() ?: null,
+                    buildSpecification: $resource->getBuildSpecification() ?: null,
+                    runtimeSpecification: $resource->getRuntimeSpecification() ?: null,
                 );
                 break;
             case Resource::TYPE_SITE_VARIABLE:

--- a/src/Migration/Resources/Functions/Func.php
+++ b/src/Migration/Resources/Functions/Func.php
@@ -22,6 +22,7 @@ class Func extends Resource
      * @param bool $logging
      * @param array<string> $scopes
      * @param string $specification
+     * @param string $buildSpecification
      */
     public function __construct(
         string $id,
@@ -37,7 +38,8 @@ class Func extends Resource
         private readonly string $commands = '',
         private readonly bool $logging = true,
         private readonly array $scopes = [],
-        private readonly string $specification = ''
+        private readonly string $specification = '',
+        private readonly string $buildSpecification = ''
     ) {
         $this->id = $id;
     }
@@ -62,7 +64,8 @@ class Func extends Resource
             $array['commands'] ?? '',
             $array['logging'] ?? true,
             $array['scopes'] ?? [],
-            $array['specification'] ?? ''
+            $array['runtimeSpecification'] ?? $array['specification'] ?? '',
+            $array['buildSpecification'] ?? $array['specification'] ?? ''
         );
     }
 
@@ -86,6 +89,8 @@ class Func extends Resource
             'logging' => $this->logging,
             'scopes' => $this->scopes,
             'specification' => $this->specification,
+            'runtimeSpecification' => $this->specification,
+            'buildSpecification' => $this->buildSpecification,
         ];
     }
 
@@ -171,5 +176,15 @@ class Func extends Resource
     public function getSpecification(): string
     {
         return $this->specification;
+    }
+
+    public function getRuntimeSpecification(): string
+    {
+        return $this->specification;
+    }
+
+    public function getBuildSpecification(): string
+    {
+        return $this->buildSpecification ?: $this->specification;
     }
 }

--- a/src/Migration/Resources/Sites/Site.php
+++ b/src/Migration/Resources/Sites/Site.php
@@ -22,6 +22,7 @@ class Site extends Resource
      * @param string $fallbackFile
      * @param string $specification
      * @param string $activeDeployment
+     * @param string $buildSpecification
      */
     public function __construct(
         string $id,
@@ -37,7 +38,8 @@ class Site extends Resource
         private readonly string $adapter = 'static',
         private readonly string $fallbackFile = '',
         private readonly string $specification = '',
-        private readonly string $activeDeployment = ''
+        private readonly string $activeDeployment = '',
+        private readonly string $buildSpecification = ''
     ) {
         $this->id = $id;
     }
@@ -61,8 +63,9 @@ class Site extends Resource
             $array['outputDirectory'] ?? '',
             $array['adapter'] ?? 'static',
             $array['fallbackFile'] ?? '',
-            $array['specification'] ?? '',
-            $array['activeDeployment'] ?? ''
+            $array['runtimeSpecification'] ?? $array['specification'] ?? '',
+            $array['activeDeployment'] ?? '',
+            $array['buildSpecification'] ?? $array['specification'] ?? ''
         );
     }
 
@@ -85,7 +88,9 @@ class Site extends Resource
             'adapter' => $this->adapter,
             'fallbackFile' => $this->fallbackFile,
             'specification' => $this->specification,
+            'runtimeSpecification' => $this->specification,
             'activeDeployment' => $this->activeDeployment,
+            'buildSpecification' => $this->buildSpecification,
         ];
     }
 
@@ -157,6 +162,16 @@ class Site extends Resource
     public function getSpecification(): string
     {
         return $this->specification;
+    }
+
+    public function getRuntimeSpecification(): string
+    {
+        return $this->specification;
+    }
+
+    public function getBuildSpecification(): string
+    {
+        return $this->buildSpecification ?: $this->specification;
     }
 
     public function getActiveDeployment(): string

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -2149,7 +2149,8 @@ class Appwrite extends Source
                     $function->commands ?? '',
                     $function->logging ?? true,
                     $function->scopes ?? [],
-                    $function->runtimeSpecification ?: $function->buildSpecification ?: '',
+                    $function->runtimeSpecification ?: '',
+                    $function->buildSpecification ?: '',
                 );
                 $functions[] = $convertedFunc;
 
@@ -2732,8 +2733,9 @@ class Appwrite extends Source
                     $site->outputDirectory ?? '',
                     $site->adapter ?? 'static',
                     $site->fallbackFile ?? '',
-                    $site->runtimeSpecification ?: $site->buildSpecification ?: '',
-                    $site->deploymentId ?? ''
+                    $site->runtimeSpecification ?: '',
+                    $site->deploymentId ?? '',
+                    $site->buildSpecification ?: ''
                 );
                 $sites[] = $convertedSite;
                 $convertedResources[] = $convertedSite;

--- a/tests/Migration/Unit/Resources/SpecificationTest.php
+++ b/tests/Migration/Unit/Resources/SpecificationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Utopia\Tests\Unit\Resources;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Migration\Resources\Functions\Func;
+use Utopia\Migration\Resources\Sites\Site;
+
+class SpecificationTest extends TestCase
+{
+    public function testFunctionPreservesBuildAndRuntimeSpecifications(): void
+    {
+        $function = Func::fromArray([
+            'id' => 'function',
+            'name' => 'Function',
+            'runtime' => 'php-8.4',
+            'runtimeSpecification' => 's-1vcpu-512mb',
+            'buildSpecification' => 's-2vcpu-2gb',
+        ]);
+
+        $this->assertSame('s-1vcpu-512mb', $function->getRuntimeSpecification());
+        $this->assertSame('s-2vcpu-2gb', $function->getBuildSpecification());
+        $this->assertSame('s-1vcpu-512mb', $function->jsonSerialize()['runtimeSpecification']);
+        $this->assertSame('s-2vcpu-2gb', $function->jsonSerialize()['buildSpecification']);
+    }
+
+    public function testSitePreservesBuildAndRuntimeSpecifications(): void
+    {
+        $site = Site::fromArray([
+            'id' => 'site',
+            'name' => 'Site',
+            'framework' => 'other',
+            'buildRuntime' => 'node-22',
+            'runtimeSpecification' => 's-1vcpu-512mb',
+            'buildSpecification' => 's-2vcpu-2gb',
+        ]);
+
+        $this->assertSame('s-1vcpu-512mb', $site->getRuntimeSpecification());
+        $this->assertSame('s-2vcpu-2gb', $site->getBuildSpecification());
+        $this->assertSame('s-1vcpu-512mb', $site->jsonSerialize()['runtimeSpecification']);
+        $this->assertSame('s-2vcpu-2gb', $site->jsonSerialize()['buildSpecification']);
+    }
+
+    public function testLegacySpecificationIsUsedForBuildAndRuntime(): void
+    {
+        $function = Func::fromArray([
+            'id' => 'function',
+            'name' => 'Function',
+            'runtime' => 'php-8.4',
+            'specification' => 's-1vcpu-512mb',
+        ]);
+
+        $this->assertSame('s-1vcpu-512mb', $function->getRuntimeSpecification());
+        $this->assertSame('s-1vcpu-512mb', $function->getBuildSpecification());
+    }
+}


### PR DESCRIPTION
## Summary
- preserve build and runtime specifications independently when exporting functions and sites
- apply each source specification to the matching destination field
- retain compatibility with legacy resources that only contain `specification`
- add focused serialization and compatibility coverage

## Testing
- `composer lint`
- `./vendor/bin/phpunit tests/Migration/Unit/Resources`
- targeted PHPStan analysis for the changed resource classes and tests
- PHP syntax checks for all changed PHP files