### PR TITLE
Address vectorsdb dimension review comments

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -1335,7 +1335,7 @@ class Appwrite extends Destination
             return;
         }
 
-        if ((int) $table->getAttribute('dimension', 0) === $resource->getSize()) {
+        if ((int) $table->getAttribute('dimension', 0) !== 0) {
             return;
         }
 

--- a/src/Migration/Resources/Database/Collection.php
+++ b/src/Migration/Resources/Database/Collection.php
@@ -72,8 +72,12 @@ class Collection extends Table
      */
     public function jsonSerialize(): array
     {
-        return array_merge(parent::jsonSerialize(), [
-            'dimension' => $this->dimension,
-        ]);
+        $data = parent::jsonSerialize();
+
+        if ($this->dimension !== null) {
+            $data['dimension'] = $this->dimension;
+        }
+
+        return $data;
     }
 }

--- a/tests/Migration/Unit/Resources/CollectionTest.php
+++ b/tests/Migration/Unit/Resources/CollectionTest.php
@@ -53,6 +53,6 @@ class CollectionTest extends TestCase
         ]);
 
         $this->assertNull($collection->getDimension());
-        $this->assertNull($collection->jsonSerialize()['dimension']);
+        $this->assertArrayNotHasKey('dimension', $collection->jsonSerialize());
     }
 }


### PR DESCRIPTION
Follow-up to #210 — the two Greptile findings were fixed on the branch but #210 merged moments before the push, so they missed the merge.

- **P1**: `syncVectorDimension` now only writes when the collection's `dimension` is still the placeholder `0`, so it fills the value for pre-dimension archives but never overwrites an archived dimension; additional vector column imports are no-ops.
- **P2**: `Collection::jsonSerialize` omits `dimension` when unset, so documentsdb and other non-vector collection archive lines keep their previous shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)