### PR TITLE
Drive vectorsdb dimension from the embeddings column only

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -87,6 +87,8 @@ class Appwrite extends Destination
     private const META_ATTRIBUTES = 'attributes';
     private const META_INDEXES = 'indexes';
 
+    private const VECTORSDB_EMBEDDINGS_KEY = 'embeddings';
+
     /** A database is provisioning while its resources transfer, ready once the run completes, or failed if creation errored. */
     private const DATABASE_STATUS_PROVISIONING = 'provisioning';
     private const DATABASE_STATUS_READY = 'ready';
@@ -1323,19 +1325,24 @@ class Appwrite extends Destination
     }
 
     /**
+     * The `embeddings` column is the schema-defining vector of a vectorsdb collection, so it alone
+     * drives the collection's `dimension` — correcting both the pre-dimension-archive placeholder
+     * and any stale archived value, while other vector columns never touch it.
+     *
      * @throws \Throwable
      */
     private function syncVectorDimension(Column|Attribute $resource, string $type, UtopiaDocument $database, UtopiaDocument $table): void
     {
         if (
             $type !== UtopiaDatabase::VAR_VECTOR
+            || $resource->getKey() !== self::VECTORSDB_EMBEDDINGS_KEY
             || $resource->getTable()->getDatabase()->getType() !== Resource::TYPE_DATABASE_VECTORSDB
             || !isset($this->collectionStructures[Resource::TYPE_DATABASE_VECTORSDB])
         ) {
             return;
         }
 
-        if ((int) $table->getAttribute('dimension', 0) !== 0) {
+        if ((int) $table->getAttribute('dimension', 0) === $resource->getSize()) {
             return;
         }
 


### PR DESCRIPTION
Addresses the P1 on #211: the placeholder-only guard left a stale archived `dimension` uncorrected when it disagreed with the actual vector column size, while the pre-#211 behavior overwrote it from any vector column (the P1 on #210).

The `embeddings` column is the schema-defining vector of a vectorsdb collection, so it alone now drives `dimension`: mismatches (including the pre-dimension-archive placeholder) are corrected from its size, and other vector columns never touch the value. This satisfies both review findings simultaneously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)