### PR TITLE
chore: upgrade storage to v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY composer.lock /app
 RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist;
 
-FROM php:8.3.10-cli-alpine3.20 AS tests
+FROM php:8.5-cli-alpine AS tests
 
 # Postgres
 RUN set -ex \

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-openssl": "*",
         "appwrite/appwrite": "^26.0",
         "utopia-php/database": "^6.0.0",
-        "utopia-php/storage": "3.*",
+        "utopia-php/storage": "4.*",
         "utopia-php/dsn": "0.2.*",
         "halaxa/json-machine": "^1.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f6a3deb25cfff3872ef143871d101b2",
+    "content-hash": "87dc885354b7a0f8d02241973e89186d",
     "packages": [
         {
             "name": "appwrite/appwrite",
@@ -2671,16 +2671,16 @@
         },
         {
             "name": "utopia-php/storage",
-            "version": "3.0.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/storage.git",
-                "reference": "171746978543323c2536edacd8ad8e8d3fde401c"
+                "reference": "ad05f341a9a62a4de73c5312f4ab6fe69f7d0051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/storage/zipball/171746978543323c2536edacd8ad8e8d3fde401c",
-                "reference": "171746978543323c2536edacd8ad8e8d3fde401c",
+                "url": "https://api.github.com/repos/utopia-php/storage/zipball/ad05f341a9a62a4de73c5312f4ab6fe69f7d0051",
+                "reference": "ad05f341a9a62a4de73c5312f4ab6fe69f7d0051",
                 "shasum": ""
             },
             "require": {
@@ -2715,9 +2715,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/storage/issues",
-                "source": "https://github.com/utopia-php/storage/tree/3.0.0"
+                "source": "https://github.com/utopia-php/storage/tree/4.0.0"
             },
-            "time": "2026-07-20T13:15:54+00:00"
+            "time": "2026-07-23T20:37:10+00:00"
         },
         {
             "name": "utopia-php/telemetry",

--- a/src/Migration/Destinations/CSV.php
+++ b/src/Migration/Destinations/CSV.php
@@ -200,7 +200,7 @@ class CSV extends Destination
         }
 
         try {
-            $result = $this->local->transfer(
+            $result = $this->local->copy(
                 $sourcePath,
                 $destPath,
                 $this->deviceForFiles,

--- a/src/Migration/Destinations/JSON.php
+++ b/src/Migration/Destinations/JSON.php
@@ -219,7 +219,7 @@ class JSON extends Destination
         }
 
         try {
-            $result = $this->local->transfer(
+            $result = $this->local->copy(
                 $sourcePath,
                 $destPath,
                 $this->deviceForFiles,

--- a/src/Migration/Sources/CSV.php
+++ b/src/Migration/Sources/CSV.php
@@ -574,7 +574,7 @@ class CSV extends Source
         }
 
         try {
-            $success = $device->transfer(
+            $success = $device->copy(
                 $filePath,
                 $filePath,
                 new Device\Local('/'),

--- a/src/Migration/Sources/JSON.php
+++ b/src/Migration/Sources/JSON.php
@@ -309,7 +309,7 @@ class JSON extends Source
         }
 
         try {
-            $success = $device->transfer(
+            $success = $device->copy(
                 $filePath,
                 $filePath,
                 new Device\Local('/'),


### PR DESCRIPTION
## Summary

- upgrade utopia-php/storage from v3 to v4
- migrate storage transfers to the new copy API
- update the test runtime to PHP 8.5

## Testing

- composer validate --strict
- composer lint
- composer check
- PHPUnit unit suite: 64 tests, 386 assertions
- Dockerized full suite: 86 tests, 470 assertions