### PR TITLE
DISCORD-15363566 fix(sources): resolve column type, format and size the way Appwrite does

### DIFF
--- a/src/Migration/Resources/Database/Column.php
+++ b/src/Migration/Resources/Database/Column.php
@@ -2,6 +2,7 @@
 
 namespace Utopia\Migration\Resources\Database;
 
+use Utopia\Database\Database as UtopiaDatabase;
 use Utopia\Migration\Resource;
 use Utopia\Migration\Transfer;
 
@@ -30,6 +31,82 @@ abstract class Column extends Resource
 
     public const TYPE_OBJECT = 'object';
     public const TYPE_VECTOR = 'vector';
+
+    /**
+     * Types whose size is fixed by the type itself. Appwrite leaves the size
+     * off the API response for these, so it has to be derived from the type.
+     *
+     * Mirrors Appwrite\Utopia\Database\Attribute::SIZES.
+     *
+     * @var array<string, int>
+     */
+    public const SIZES = [
+        self::TYPE_TEXT => 65535,
+        self::TYPE_MEDIUMTEXT => 16777215,
+        self::TYPE_LONGTEXT => 2147483647,
+    ];
+
+    /**
+     * String formats, mapped to the size Appwrite creates them with. Each
+     * format is also accepted as a shorthand type on an inline column
+     * definition, where it means a string of that format.
+     *
+     * Mirrors Appwrite\Utopia\Database\Attribute::FORMAT_SIZES.
+     *
+     * @var array<string, int>
+     */
+    public const FORMAT_SIZES = [
+        self::TYPE_EMAIL => 254,
+        self::TYPE_ENUM => UtopiaDatabase::LENGTH_KEY,
+        self::TYPE_IP => 39,
+        self::TYPE_URL => 2000,
+    ];
+
+    /**
+     * Size to fall back on for a varchar that arrives without one. Appwrite
+     * requires an explicit size for varchar, so this only guards a source
+     * that omits it.
+     */
+    public const DEFAULT_VARCHAR_SIZE = 255;
+
+    /**
+     * Resolve a raw column definition into the type, format and size Appwrite
+     * stores for it. A format shorthand (`email`, `url`, `ip`, `enum`) becomes
+     * a string of that format, and an omitted size is filled in from the type
+     * or the format.
+     *
+     * Mirrors Appwrite\Utopia\Database\Attribute::resolve() so a column read
+     * from a source ends up with the size the destination would have stored.
+     *
+     * @param array<string, mixed> $column
+     * @return array{type: string, format: string, size: int}
+     */
+    public static function resolve(array $column): array
+    {
+        $type = \is_string($column['type'] ?? null) ? $column['type'] : '';
+        $format = \is_string($column['format'] ?? null) ? $column['format'] : '';
+
+        if (isset(self::FORMAT_SIZES[$type])) {
+            $format = $type;
+            $type = self::TYPE_STRING;
+        }
+
+        $size = $column['size'] ?? null;
+        $size = \is_numeric($size) ? (int) $size : 0;
+
+        if (isset(self::SIZES[$type])) {
+            // Fixed width types ignore any size the source reported.
+            $size = self::SIZES[$type];
+        } elseif ($size < 1) {
+            $size = self::FORMAT_SIZES[$format] ?? $size;
+        }
+
+        return [
+            'type' => $type,
+            'format' => $format,
+            'size' => $size,
+        ];
+    }
 
     /**
      * @param string $key

--- a/src/Migration/Resources/Database/Columns/Email.php
+++ b/src/Migration/Resources/Database/Columns/Email.php
@@ -13,7 +13,7 @@ class Email extends Text
         bool    $required = false,
         ?string $default = null,
         bool    $array = false,
-        int     $size = 254,
+        int     $size = Column::FORMAT_SIZES[Column::TYPE_EMAIL],
         string  $createdAt = '',
         string  $updatedAt = ''
     ) {

--- a/src/Migration/Resources/Database/Columns/Enum.php
+++ b/src/Migration/Resources/Database/Columns/Enum.php
@@ -17,7 +17,7 @@ class Enum extends Column
         bool    $required = false,
         ?string $default = null,
         bool    $array = false,
-        int     $size = 256,
+        int     $size = Column::FORMAT_SIZES[Column::TYPE_ENUM],
         string  $createdAt = '',
         string  $updatedAt = ''
     ) {

--- a/src/Migration/Resources/Database/Columns/IP.php
+++ b/src/Migration/Resources/Database/Columns/IP.php
@@ -13,7 +13,7 @@ class IP extends Text
         bool    $required = false,
         ?string $default = null,
         bool    $array = false,
-        int     $size = 39,
+        int     $size = Column::FORMAT_SIZES[Column::TYPE_IP],
         string  $createdAt = '',
         string  $updatedAt = ''
     ) {

--- a/src/Migration/Resources/Database/Columns/LongText.php
+++ b/src/Migration/Resources/Database/Columns/LongText.php
@@ -14,7 +14,7 @@ class LongText extends Column
         bool    $required = false,
         ?string $default = null,
         bool    $array = false,
-        int     $size = 2147483647,
+        int     $size = Column::SIZES[Column::TYPE_LONGTEXT],
         string  $format = '',
         string  $createdAt = '',
         string  $updatedAt = ''

--- a/src/Migration/Resources/Database/Columns/MediumText.php
+++ b/src/Migration/Resources/Database/Columns/MediumText.php
@@ -14,7 +14,7 @@ class MediumText extends Column
         bool    $required = false,
         ?string $default = null,
         bool    $array = false,
-        int     $size = 16777215,
+        int     $size = Column::SIZES[Column::TYPE_MEDIUMTEXT],
         string  $format = '',
         string  $createdAt = '',
         string  $updatedAt = ''

--- a/src/Migration/Resources/Database/Columns/RegularText.php
+++ b/src/Migration/Resources/Database/Columns/RegularText.php
@@ -14,7 +14,7 @@ class RegularText extends Column
         bool    $required = false,
         ?string $default = null,
         bool    $array = false,
-        int     $size = 65535,
+        int     $size = Column::SIZES[Column::TYPE_TEXT],
         string  $format = '',
         string  $createdAt = '',
         string  $updatedAt = ''

--- a/src/Migration/Resources/Database/Columns/URL.php
+++ b/src/Migration/Resources/Database/Columns/URL.php
@@ -13,7 +13,7 @@ class URL extends Text
         bool    $required = false,
         ?string $default = null,
         bool    $array = false,
-        int     $size = 2000,
+        int     $size = Column::FORMAT_SIZES[Column::TYPE_URL],
         string  $createdAt = '',
         string  $updatedAt = ''
     ) {

--- a/src/Migration/Resources/Database/Columns/Varchar.php
+++ b/src/Migration/Resources/Database/Columns/Varchar.php
@@ -14,7 +14,7 @@ class Varchar extends Column
         bool    $required = false,
         ?string $default = null,
         bool    $array = false,
-        int     $size = 255,
+        int     $size = Column::DEFAULT_VARCHAR_SIZE,
         string  $format = '',
         string  $createdAt = '',
         string  $updatedAt = ''

--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -3269,15 +3269,20 @@ class Appwrite extends Source
 
     public static function getColumn(Table $table, mixed $column): Column
     {
-        return match ($column['type']) {
-            Column::TYPE_STRING => match ($column['format'] ?? '') {
+        // Appwrite accepts a format (`email`, `url`, `ip`, `enum`) as a type on
+        // an inline column definition, and reports no size for the types whose
+        // size the type itself implies. Resolve both the way the server does.
+        ['type' => $type, 'format' => $format, 'size' => $size] = Column::resolve($column);
+
+        return match ($type) {
+            Column::TYPE_STRING => match ($format) {
                 Column::TYPE_EMAIL => new Email(
                     $column['key'],
                     $table,
                     required: $column['required'],
                     default: $column['default'],
                     array: $column['array'],
-                    size: $column['size'] ?? 254,
+                    size: $size,
                     createdAt: $column['$createdAt'] ?? '',
                     updatedAt: $column['$updatedAt'] ?? '',
                 ),
@@ -3288,7 +3293,7 @@ class Appwrite extends Source
                     required: $column['required'],
                     default: $column['default'],
                     array: $column['array'],
-                    size: $column['size'] ?? UtopiaDatabase::LENGTH_KEY,
+                    size: $size,
                     createdAt: $column['$createdAt'] ?? '',
                     updatedAt: $column['$updatedAt'] ?? '',
                 ),
@@ -3298,7 +3303,7 @@ class Appwrite extends Source
                     required: $column['required'],
                     default: $column['default'],
                     array: $column['array'],
-                    size: $column['size'] ?? 2000,
+                    size: $size,
                     createdAt: $column['$createdAt'] ?? '',
                     updatedAt: $column['$updatedAt'] ?? '',
                 ),
@@ -3308,7 +3313,7 @@ class Appwrite extends Source
                     required: $column['required'],
                     default: $column['default'],
                     array: $column['array'],
-                    size: $column['size'] ?? 39,
+                    size: $size,
                     createdAt: $column['$createdAt'] ?? '',
                     updatedAt: $column['$updatedAt'] ?? '',
                 ),
@@ -3318,7 +3323,7 @@ class Appwrite extends Source
                     required: $column['required'],
                     default: $column['default'],
                     array: $column['array'],
-                    size: $column['size'] ?? 0,
+                    size: $size,
                     createdAt: $column['$createdAt'] ?? '',
                     updatedAt: $column['$updatedAt'] ?? '',
                 ),
@@ -3446,7 +3451,7 @@ class Appwrite extends Source
                 required: $column['required'],
                 default: $column['default'],
                 array: $column['array'],
-                size: $column['size'] ?? 255,
+                size: $size ?: Column::DEFAULT_VARCHAR_SIZE,
                 createdAt: $column['$createdAt'] ?? '',
                 updatedAt: $column['$updatedAt'] ?? '',
             ),
@@ -3457,7 +3462,7 @@ class Appwrite extends Source
                 required: $column['required'],
                 default: $column['default'],
                 array: $column['array'],
-                size: $column['size'] ?? 65535,
+                size: $size,
                 createdAt: $column['$createdAt'] ?? '',
                 updatedAt: $column['$updatedAt'] ?? '',
             ),
@@ -3468,7 +3473,7 @@ class Appwrite extends Source
                 required: $column['required'],
                 default: $column['default'],
                 array: $column['array'],
-                size: $column['size'] ?? 16777215,
+                size: $size,
                 createdAt: $column['$createdAt'] ?? '',
                 updatedAt: $column['$updatedAt'] ?? '',
             ),
@@ -3479,13 +3484,13 @@ class Appwrite extends Source
                 required: $column['required'],
                 default: $column['default'],
                 array: $column['array'],
-                size: $column['size'] ?? 2147483647,
+                size: $size,
                 createdAt: $column['$createdAt'] ?? '',
                 updatedAt: $column['$updatedAt'] ?? '',
             ),
 
 
-            default => throw new \InvalidArgumentException("Unsupported column type: {$column['type']}"),
+            default => throw new \InvalidArgumentException("Unsupported column type: {$type}"),
         };
     }
 

--- a/tests/Migration/Unit/Resources/ColumnTest.php
+++ b/tests/Migration/Unit/Resources/ColumnTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Utopia\Tests\Unit\Resources;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database as UtopiaDatabase;
+use Utopia\Migration\Resources\Database\Column;
+
+/**
+ * Lock-in for Column::resolve(), which mirrors the type/format/size mapping
+ * Appwrite applies in Appwrite\Utopia\Database\Attribute. If the two drift, a
+ * migrated column lands on the destination with a different size than the one
+ * the source project created it with.
+ */
+class ColumnTest extends TestCase
+{
+    public function testFixedWidthTypesDeriveTheirSize(): void
+    {
+        $this->assertSame(
+            ['type' => Column::TYPE_TEXT, 'format' => '', 'size' => 65535],
+            Column::resolve(['key' => 'body', 'type' => Column::TYPE_TEXT]),
+        );
+
+        $this->assertSame(
+            ['type' => Column::TYPE_MEDIUMTEXT, 'format' => '', 'size' => 16777215],
+            Column::resolve(['key' => 'summary', 'type' => Column::TYPE_MEDIUMTEXT]),
+        );
+
+        $this->assertSame(
+            ['type' => Column::TYPE_LONGTEXT, 'format' => '', 'size' => 2147483647],
+            Column::resolve(['key' => 'archive', 'type' => Column::TYPE_LONGTEXT]),
+        );
+    }
+
+    public function testFixedWidthTypesIgnoreAReportedSize(): void
+    {
+        $this->assertSame(
+            ['type' => Column::TYPE_TEXT, 'format' => '', 'size' => 65535],
+            Column::resolve(['key' => 'body', 'type' => Column::TYPE_TEXT, 'size' => 128]),
+        );
+    }
+
+    public function testFormatShorthandsBecomeAString(): void
+    {
+        $this->assertSame(
+            ['type' => Column::TYPE_STRING, 'format' => Column::TYPE_EMAIL, 'size' => 254],
+            Column::resolve(['key' => 'email', 'type' => Column::TYPE_EMAIL]),
+        );
+
+        $this->assertSame(
+            ['type' => Column::TYPE_STRING, 'format' => Column::TYPE_URL, 'size' => 2000],
+            Column::resolve(['key' => 'website', 'type' => Column::TYPE_URL]),
+        );
+
+        $this->assertSame(
+            ['type' => Column::TYPE_STRING, 'format' => Column::TYPE_IP, 'size' => 39],
+            Column::resolve(['key' => 'address', 'type' => Column::TYPE_IP]),
+        );
+
+        $this->assertSame(
+            ['type' => Column::TYPE_STRING, 'format' => Column::TYPE_ENUM, 'size' => UtopiaDatabase::LENGTH_KEY],
+            Column::resolve(['key' => 'status', 'type' => Column::TYPE_ENUM]),
+        );
+    }
+
+    public function testFormattedStringWithoutSizeFallsBackToTheFormatSize(): void
+    {
+        $this->assertSame(
+            ['type' => Column::TYPE_STRING, 'format' => Column::TYPE_EMAIL, 'size' => 254],
+            Column::resolve([
+                'key' => 'email',
+                'type' => Column::TYPE_STRING,
+                'format' => Column::TYPE_EMAIL,
+            ]),
+        );
+    }
+
+    public function testExplicitSizeWins(): void
+    {
+        $this->assertSame(
+            ['type' => Column::TYPE_STRING, 'format' => Column::TYPE_EMAIL, 'size' => 512],
+            Column::resolve(['key' => 'email', 'type' => Column::TYPE_EMAIL, 'size' => 512]),
+        );
+
+        $this->assertSame(
+            ['type' => Column::TYPE_VARCHAR, 'format' => '', 'size' => 64],
+            Column::resolve(['key' => 'slug', 'type' => Column::TYPE_VARCHAR, 'size' => 64]),
+        );
+
+        // A size that survived a round trip through a string stays a size.
+        $this->assertSame(
+            ['type' => Column::TYPE_VARCHAR, 'format' => '', 'size' => 64],
+            Column::resolve(['key' => 'slug', 'type' => Column::TYPE_VARCHAR, 'size' => '64']),
+        );
+    }
+
+    public function testUnsizedAndUnknownDefinitionsResolveToZero(): void
+    {
+        $this->assertSame(
+            ['type' => Column::TYPE_VARCHAR, 'format' => '', 'size' => 0],
+            Column::resolve(['key' => 'slug', 'type' => Column::TYPE_VARCHAR]),
+        );
+
+        $this->assertSame(
+            ['type' => '', 'format' => '', 'size' => 0],
+            Column::resolve(['key' => 'unknown']),
+        );
+    }
+}

--- a/tests/Migration/Unit/Sources/AppwriteColumnTest.php
+++ b/tests/Migration/Unit/Sources/AppwriteColumnTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Utopia\Tests\Unit\Sources;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database as UtopiaDatabase;
+use Utopia\Migration\Resources\Database\Column;
+use Utopia\Migration\Resources\Database\Columns\Email;
+use Utopia\Migration\Resources\Database\Columns\Enum;
+use Utopia\Migration\Resources\Database\Columns\IP;
+use Utopia\Migration\Resources\Database\Columns\LongText;
+use Utopia\Migration\Resources\Database\Columns\MediumText;
+use Utopia\Migration\Resources\Database\Columns\RegularText;
+use Utopia\Migration\Resources\Database\Columns\Text;
+use Utopia\Migration\Resources\Database\Columns\URL;
+use Utopia\Migration\Resources\Database\Columns\Varchar;
+use Utopia\Migration\Resources\Database\Database;
+use Utopia\Migration\Resources\Database\Table;
+use Utopia\Migration\Sources\Appwrite;
+
+/**
+ * Column parsing for the string type family. Appwrite reports no size for the
+ * fixed width types (`text`, `mediumtext`, `longtext`) or for the strings that
+ * are backed by a format (`email`, `url`, `ip`, `enum`) — the size is implied
+ * — and it accepts a format as a type on an inline column definition. Either
+ * shape has to come out of the source carrying the size the destination will
+ * recreate the column with.
+ */
+class AppwriteColumnTest extends TestCase
+{
+    private Table $table;
+
+    protected function setUp(): void
+    {
+        $this->table = new Table(new Database('main', 'Main'), 'Modules', 'modules');
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function payload(array $overrides): array
+    {
+        return \array_merge([
+            'key' => 'column',
+            'required' => false,
+            'default' => null,
+            'array' => false,
+            '$createdAt' => '2026-01-01T00:00:00.000+00:00',
+            '$updatedAt' => '2026-01-01T00:00:00.000+00:00',
+        ], $overrides);
+    }
+
+    public function testFixedWidthTypesWithoutASize(): void
+    {
+        $text = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'modulePath',
+            'type' => Column::TYPE_TEXT,
+        ]));
+
+        $this->assertInstanceOf(RegularText::class, $text);
+        $this->assertSame(Column::TYPE_TEXT, $text->getType());
+        $this->assertSame(65535, $text->getSize());
+
+        $medium = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'summary',
+            'type' => Column::TYPE_MEDIUMTEXT,
+        ]));
+
+        $this->assertInstanceOf(MediumText::class, $medium);
+        $this->assertSame(Column::TYPE_MEDIUMTEXT, $medium->getType());
+        $this->assertSame(16777215, $medium->getSize());
+
+        $long = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'archive',
+            'type' => Column::TYPE_LONGTEXT,
+        ]));
+
+        $this->assertInstanceOf(LongText::class, $long);
+        $this->assertSame(Column::TYPE_LONGTEXT, $long->getType());
+        $this->assertSame(2147483647, $long->getSize());
+    }
+
+    public function testVarcharKeepsItsSize(): void
+    {
+        $varchar = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'slug',
+            'type' => Column::TYPE_VARCHAR,
+            'size' => 64,
+        ]));
+
+        $this->assertInstanceOf(Varchar::class, $varchar);
+        $this->assertSame(Column::TYPE_VARCHAR, $varchar->getType());
+        $this->assertSame(64, $varchar->getSize());
+    }
+
+    public function testStringKeepsItsSize(): void
+    {
+        $string = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'title',
+            'type' => Column::TYPE_STRING,
+            'size' => 128,
+            'format' => '',
+        ]));
+
+        $this->assertInstanceOf(Text::class, $string);
+        $this->assertSame(Column::TYPE_STRING, $string->getType());
+        $this->assertSame(128, $string->getSize());
+    }
+
+    public function testFormattedStringsWithoutASize(): void
+    {
+        $email = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'email',
+            'type' => Column::TYPE_STRING,
+            'format' => Column::TYPE_EMAIL,
+        ]));
+
+        $this->assertInstanceOf(Email::class, $email);
+        $this->assertSame(Column::TYPE_EMAIL, $email->getFormat());
+        $this->assertSame(254, $email->getSize());
+
+        $url = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'website',
+            'type' => Column::TYPE_STRING,
+            'format' => Column::TYPE_URL,
+        ]));
+
+        $this->assertInstanceOf(URL::class, $url);
+        $this->assertSame(2000, $url->getSize());
+
+        $ip = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'address',
+            'type' => Column::TYPE_STRING,
+            'format' => Column::TYPE_IP,
+        ]));
+
+        $this->assertInstanceOf(IP::class, $ip);
+        $this->assertSame(39, $ip->getSize());
+
+        $enum = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'status',
+            'type' => Column::TYPE_STRING,
+            'format' => Column::TYPE_ENUM,
+            'elements' => ['on', 'off'],
+        ]));
+
+        $this->assertInstanceOf(Enum::class, $enum);
+        $this->assertSame(UtopiaDatabase::LENGTH_KEY, $enum->getSize());
+        $this->assertSame(['on', 'off'], $enum->getElements());
+    }
+
+    public function testFormatShorthandResolvesLikeTheFormattedString(): void
+    {
+        $shorthand = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'email',
+            'type' => Column::TYPE_EMAIL,
+        ]));
+
+        $formatted = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'email',
+            'type' => Column::TYPE_STRING,
+            'format' => Column::TYPE_EMAIL,
+        ]));
+
+        $this->assertEquals($formatted->jsonSerialize(), $shorthand->jsonSerialize());
+    }
+
+    public function testFormatShorthandUsedAsAType(): void
+    {
+        $email = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'email',
+            'type' => Column::TYPE_EMAIL,
+        ]));
+
+        $this->assertInstanceOf(Email::class, $email);
+        $this->assertSame(Column::TYPE_EMAIL, $email->getFormat());
+        $this->assertSame(254, $email->getSize());
+
+        $url = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'website',
+            'type' => Column::TYPE_URL,
+        ]));
+
+        $this->assertInstanceOf(URL::class, $url);
+        $this->assertSame(Column::TYPE_URL, $url->getFormat());
+        $this->assertSame(2000, $url->getSize());
+
+        $ip = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'address',
+            'type' => Column::TYPE_IP,
+        ]));
+
+        $this->assertInstanceOf(IP::class, $ip);
+        $this->assertSame(Column::TYPE_IP, $ip->getFormat());
+        $this->assertSame(39, $ip->getSize());
+
+        $enum = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'status',
+            'type' => Column::TYPE_ENUM,
+            'elements' => ['on', 'off'],
+            'default' => 'on',
+        ]));
+
+        $this->assertInstanceOf(Enum::class, $enum);
+        $this->assertSame(Column::TYPE_ENUM, $enum->getFormat());
+        $this->assertSame(UtopiaDatabase::LENGTH_KEY, $enum->getSize());
+        $this->assertSame('on', $enum->getDefault());
+    }
+
+    public function testDerivedSizeSurvivesTheAttributeConversion(): void
+    {
+        $attribute = Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'modulePath',
+            'type' => Column::TYPE_TEXT,
+        ]))->getAttribute();
+
+        $this->assertSame(Column::TYPE_TEXT, $attribute->getType());
+        $this->assertSame(65535, $attribute->getSize());
+    }
+
+    public function testUnsupportedTypeThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported column type: blob');
+
+        Appwrite::getColumn($this->table, $this->payload([
+            'key' => 'unknown',
+            'type' => 'blob',
+        ]));
+    }
+}


### PR DESCRIPTION
## Upstream

[appwrite/appwrite#13174](https://github.com/appwrite/appwrite/pull/13174) — `DISCORD-15363566 fix(databases): support text, varchar and format column types inline`.

The inline `columns`/`attributes` array on create table/collection rejected every non-legacy string type (`text`, `varchar`, `mediumtext`, `longtext`) and had no way to ask for a format. Upstream widened the accepted types, made the format shorthands (`email`, `url`, `ip`, `enum`) usable as a `type`, and moved the type/format-to-size mapping into `Appwrite\Utopia\Database\Attribute` so the inline and dedicated per-column endpoints produce identical attribute documents.

## What changed here

That mapping is duplicated in this library — once per `Column` subclass default, again per branch of `Appwrite::getColumn()` — because Appwrite reports **no size** for the fixed width types and for the strings backed by a format (`ColumnText`, `ColumnEmail` etc. carry no `size` field), so the source has to derive it. Two divergences:

- `Enum`'s default size was `256`; Appwrite creates enum columns with `Database::LENGTH_KEY` (255).
- A definition using a format shorthand as its `type` — now valid input upstream — threw `Unsupported column type: email` rather than resolving to a string of that format.

So:

- **`Column::resolve()`** (new), mirroring `Attribute::resolve()`: a format shorthand becomes a string of that format; fixed width types take the size their type implies and ignore a reported one; a formatted string with no size falls back to the format's size. Backed by `Column::SIZES` / `Column::FORMAT_SIZES`, mirroring the server's constants.
- **`Appwrite::getColumn()`** resolves through it, so the scattered `?? 65535` / `?? 254` literals are gone and shorthand types parse.
- The `Column` subclass size defaults now read from the shared constants instead of repeating the numbers (this is what corrects `Enum`).

Sizes are load-bearing beyond creation: `attributeSpecMatches()` compares the destination's stored size against the resource's when reconciling a duplicate, so a column resolved 1 byte narrower than Appwrite would store it looks like a spec change and gets recreated.

## Dependency version

`appwrite/appwrite` stays at `^26.0` (locked at 26.1.0, the newest 26.x). The upstream change is server-side — validator and inline attribute builder — and the SDK's `createTable`/`createCollection` take `columns`/`attributes` as `?array`, so its surface is unchanged; only the param description was reworded. No published SDK release contains the PR either (27.1.0 shipped 2026-07-24, the PR merged 2026-08-11), and 27.x is an unrelated major (new billing/apps models, removed health enums) that wants its own upgrade and review rather than riding along here.

## Tests

- `tests/Migration/Unit/Resources/ColumnTest.php` — `Column::resolve()` against the server's mapping: implied sizes, shorthands, explicit size wins, fixed width ignores a reported size.
- `tests/Migration/Unit/Sources/AppwriteColumnTest.php` — `Appwrite::getColumn()` over API-shaped payloads: the fixed width types with no size, formatted strings with no size, a shorthand type resolving identically to the equivalent `string` + `format`, and the derived size surviving the `Attribute` conversion.

`composer test` (82 tests, 452 assertions), `composer lint` and `composer check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)