### PR TITLE
fix: normalize reader output

### DIFF
--- a/src/Migration/Sources/Appwrite/Reader/API.php
+++ b/src/Migration/Sources/Appwrite/Reader/API.php
@@ -155,14 +155,11 @@ class API implements Reader
      */
     public function listColumns(Table $resource, array $queries = []): array
     {
-        return \array_map(
-            fn ($column) => $column->toArray(),
-            $this->database->listColumns(
-                $resource->getDatabase()->getId(),
-                $resource->getId(),
-                $queries
-            )->columns
-        );
+        return $this->database->listColumns(
+            $resource->getDatabase()->getId(),
+            $resource->getId(),
+            $queries
+        )->toArray()['columns'];
     }
 
     /**

--- a/tests/Migration/Unit/Sources/AppwriteReaderApiTest.php
+++ b/tests/Migration/Unit/Sources/AppwriteReaderApiTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Utopia\Tests\Unit\Sources;
+
+use Appwrite\Models\ColumnList;
+use Appwrite\Services\TablesDB;
+use PHPUnit\Framework\TestCase;
+use Utopia\Migration\Resources\Database\Database;
+use Utopia\Migration\Resources\Database\Table;
+use Utopia\Migration\Sources\Appwrite\Reader\API;
+
+final class AppwriteReaderApiTest extends TestCase
+{
+    public function testListColumnsNormalizesSdkListResponse(): void
+    {
+        $columns = [
+            [
+                'key' => 'title',
+                'type' => 'string',
+                'status' => 'available',
+                'error' => '',
+                'required' => true,
+                'array' => false,
+                '$createdAt' => '2026-08-12T00:00:00.000+00:00',
+                '$updatedAt' => '2026-08-12T00:00:00.000+00:00',
+                'size' => 255,
+                'default' => null,
+                'encrypt' => false,
+            ],
+        ];
+
+        $database = new Database('database', 'Database');
+        $table = new Table($database, 'Table', 'table');
+
+        $tables = $this->createMock(TablesDB::class);
+        $tables
+            ->expects($this->once())
+            ->method('listColumns')
+            ->with('database', 'table', [])
+            ->willReturn(ColumnList::from([
+                'total' => 1,
+                'columns' => $columns,
+            ]));
+
+        $this->assertSame($columns, (new API($tables))->listColumns($table));
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize Appwrite column list models at the reader boundary.
- Preserve the reader plain-array contract for polymorphic column responses.
- Add a public-path regression using the current SDK list model.

## Changes
- Read serialized columns from the SDK `ColumnList` model instead of serializing each raw entry independently.
- Cover `API::listColumns()` with real `Database` and `Table` resources and the locked Appwrite SDK 26.1.0 model.

## Scope in the DAT-2310 release train
This is a consumer-boundary compatibility leaf, not the production empty-object fix by itself. It ensures the migration reader keeps returning `list<array>` when the SDK list model materializes polymorphic column entries as already-normalized arrays. DAT-2310 still requires the coordinated HTTP, database, Mongo, server-ce, and cache fixes before an empty JSON object can be called preserved end to end.

## Test plan
- [x] Focused regression observed failing before the production change and passing afterward
- [x] Composer validation and advisory audit
- [x] Formatting and PHPStan
- [x] Unit suite: 65 tests, 391 assertions
- [x] Isolated Docker full suite: 87 tests, 475 assertions
- [x] Fresh main merge: no conflicts; 83 unit tests, 457 assertions

Refs DAT-2310