### PR TITLE
fix(destination): skip project variables with unusable keys

### DIFF
--- a/src/Migration/Destinations/Appwrite.php
+++ b/src/Migration/Destinations/Appwrite.php
@@ -89,6 +89,14 @@ class Appwrite extends Destination
 
     private const VECTORSDB_EMBEDDINGS_KEY = 'embeddings';
 
+    /**
+     * Variable keys become environment variable names at build and runtime, so
+     * the API only accepts C-style identifiers. Variables are written straight
+     * to the collection here, which skips that check, and a source project can
+     * still hold a key stored before the rule existed.
+     */
+    private const VARIABLE_KEY_PATTERN = '/^[A-Za-z_]\w*$/D';
+
     /** A database is provisioning while its resources transfer, ready once the run completes, or failed if creation errored. */
     private const DATABASE_STATUS_PROVISIONING = 'provisioning';
     private const DATABASE_STATUS_READY = 'ready';
@@ -3344,9 +3352,23 @@ class Appwrite extends Destination
 
     protected function createProjectVariable(ProjectVariable $resource): bool
     {
+        $key = $resource->getKey();
+
+        if (
+            \strlen($key) > UtopiaDatabase::LENGTH_KEY
+            || \preg_match(self::VARIABLE_KEY_PATTERN, $key) !== 1
+        ) {
+            $resource->setStatus(
+                Resource::STATUS_SKIPPED,
+                'Project variable key is not a valid environment variable name'
+            );
+
+            return false;
+        }
+
         $existing = $this->dbForProject->findOne('variables', [
             Query::equal('resourceType', ['project']),
-            Query::equal('key', [$resource->getKey()]),
+            Query::equal('key', [$key]),
         ]);
 
         if ($existing !== false && !$existing->isEmpty()) {
@@ -3357,7 +3379,6 @@ class Appwrite extends Destination
         $createdAt = $this->normalizeDateTime($resource->getCreatedAt());
         $updatedAt = $this->normalizeDateTime($resource->getUpdatedAt(), $createdAt);
         $variableId = ID::unique();
-        $key = $resource->getKey();
 
         try {
             $this->dbForProject->createDocument('variables', new UtopiaDocument([


### PR DESCRIPTION
## What

Validates a project variable's key before writing it into the `variables` collection, and skips the resource with a reason when it cannot be used.

## Why

`createProjectVariable` writes to the collection directly with `createDocument`, which bypasses the API's validation of the key. appwrite/appwrite#13181 makes the API reject keys that are not valid environment variable names (`^[A-Za-z_]\w*$`, max 255) — they become environment variable names at build and runtime, so anything else fails when the build environment is assembled.

That leaves this as the one remaining supported path that can still store an unusable key. A source project can hold one when it was stored before the rule existed, and once imported it fails at build time and can no longer be corrected through the API.

## Changes

- `VARIABLE_KEY_PATTERN` constant alongside the existing class constants.
- `createProjectVariable` checks length and shape first and sets `STATUS_SKIPPED` with a reason, mirroring how an already-existing key is reported, so one bad key does not abort the whole import.
- The key is read once into `$key` and reused by the existing duplicate lookup.

No new dependency: the check is a `preg_match` against the pattern plus `UtopiaDatabase::LENGTH_KEY`, rather than pulling in `utopia-php/validators` for a single rule.

`ProjectVariable` is the only variable resource in the library, so this covers the full surface.

## Testing

Verified with `php -l` only. `composer install` fails here with "Could not authenticate against github.com", and this machine runs PHP 8.4 against the package's `>=8.5` requirement, so the suite could not be installed or run locally — CI will be the first real run.

A test belongs here and I did not want to guess at it blind: `tests/Migration/Unit/Destinations/AppwriteDatabaseStatusTest.php` has an in-memory harness (MemoryAdapter + MockSource + a real transfer) that a `createProjectVariable` case should mirror — asserting an invalid key is skipped, no document is written, and a valid key alongside it still lands. Happy to add it if you'd prefer it in this PR.