### PR TITLE
Fix database column input normalization

### DIFF
--- a/src/Migration/Sources/Appwrite.php
+++ b/src/Migration/Sources/Appwrite.php
@@ -3269,6 +3269,10 @@ class Appwrite extends Source
 
     public static function getColumn(Table $table, mixed $column): Column
     {
+        if ($column instanceof UtopiaDocument) {
+            $column = $column->getArrayCopy();
+        }
+
         // Appwrite accepts a format (`email`, `url`, `ip`, `enum`) as a type on
         // an inline column definition, and reports no size for the types whose
         // size the type itself implies. Resolve both the way the server does.

--- a/tests/Migration/Unit/Sources/AppwriteColumnTest.php
+++ b/tests/Migration/Unit/Sources/AppwriteColumnTest.php
@@ -4,6 +4,7 @@ namespace Utopia\Tests\Unit\Sources;
 
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Database as UtopiaDatabase;
+use Utopia\Database\Document as UtopiaDocument;
 use Utopia\Migration\Resources\Database\Column;
 use Utopia\Migration\Resources\Database\Columns\Email;
 use Utopia\Migration\Resources\Database\Columns\Enum;
@@ -106,6 +107,19 @@ class AppwriteColumnTest extends TestCase
         $this->assertInstanceOf(Text::class, $string);
         $this->assertSame(Column::TYPE_STRING, $string->getType());
         $this->assertSame(128, $string->getSize());
+    }
+
+    public function testDatabaseDocumentKeepsStringSize(): void
+    {
+        $column = Appwrite::getColumn($this->table, new UtopiaDocument($this->payload([
+            'key' => 'title',
+            'type' => Column::TYPE_STRING,
+            'size' => 128,
+            'format' => '',
+        ])));
+
+        $this->assertSame(Text::class, $column::class);
+        $this->assertSame(128, $column->getSize());
     }
 
     public function testFormattedStringsWithoutASize(): void


### PR DESCRIPTION
## What changed

- normalize database-reader `Utopia\Database\Document` column records at the existing Appwrite source boundary
- preserve the existing array path and column type, format, and size resolution
- add a focused regression test using a real database document

## Verification

- red before fix: focused regression failed with `TypeError: Column::resolve(): Argument #1 ($column) must be of type array, Utopia\Database\Document given`
- green after fix: focused regression passed with 1 test and 2 assertions
- `composer format`
- `composer lint`
- `composer check`
- isolated CI-equivalent Compose suite: 106 tests, 543 assertions

The host-only full test command cannot run the eight NHost/Supabase E2E cases without their database services; the isolated Compose run supplied those services and passed the complete suite.