### PR TITLE
Add Hugging Face OAuth2 provider to migration allow-list

### DIFF
--- a/src/Migration/Resources/Auth/OAuth2/OAuth2Provider.php
+++ b/src/Migration/Resources/Auth/OAuth2/OAuth2Provider.php
@@ -49,6 +49,7 @@ final class OAuth2Provider extends Resource
         'github' => ['clientId' => ['target' => self::TARGET_APP_ID]],
         'gitlab' => ['clientId' => ['target' => self::TARGET_APP_ID], 'endpoint' => ['target' => self::TARGET_SECRET]],
         'google' => ['clientId' => ['target' => self::TARGET_APP_ID], 'prompt' => ['target' => self::TARGET_SECRET]],
+        'huggingface' => ['clientId' => ['target' => self::TARGET_APP_ID]],
         'keycloak' => [
             'clientId' => ['target' => self::TARGET_APP_ID],
             'endpoint' => ['target' => self::TARGET_SECRET, 'key' => 'keycloakDomain'],

--- a/tests/Migration/Unit/Resources/OAuth2ProviderTest.php
+++ b/tests/Migration/Unit/Resources/OAuth2ProviderTest.php
@@ -25,6 +25,24 @@ class OAuth2ProviderTest extends TestCase
         $this->assertTrue($provider->isConfigured());
     }
 
+    public function testFromArrayHuggingFace(): void
+    {
+        $provider = OAuth2Provider::fromArray('huggingface', [
+            'id' => 'huggingface',
+            'enabled' => true,
+            'clientId' => 'client-123',
+            'clientSecret' => 'super-secret',
+        ]);
+
+        $this->assertNotNull($provider);
+        $this->assertEquals('huggingface', $provider->getProviderKey());
+        $this->assertTrue($provider->getEnabled());
+        $this->assertEquals(['clientId' => 'client-123'], $provider->getSettings());
+        $this->assertEquals('client-123', $provider->getDestinationAppId());
+        $this->assertEquals([], $provider->getDestinationSecretFields());
+        $this->assertTrue($provider->isConfigured());
+    }
+
     public function testFromArrayNeverCopiesSecrets(): void
     {
         foreach (\array_keys(OAuth2Provider::PROVIDERS) as $providerKey) {


### PR DESCRIPTION
## What does this PR do?

Adds `huggingface` to the `OAuth2Provider::PROVIDERS` allow-list.

Appwrite server is adding a built-in Hugging Face OAuth2 provider ([appwrite/appwrite#13123](https://github.com/appwrite/appwrite/pull/13123)). Once that provider is enabled in `app/config/oAuthProviders.php`, it shows up in `GET /project/oauth2-providers`, and the Appwrite source enumerates it during a migration. Without an allow-list entry, `OAuth2Provider::fromArray()` returns `null` and `Sources/Appwrite.php` records:

```
{"code":500,"message":"No migration resource for OAuth2 provider 'huggingface'; skipped.","resourceName":"oauth2-provider","resourceGroup":"auth"}
```

`addError` marks the whole migration `failed`. Note the `null` check runs *before* `isConfigured()`, so this fires even for projects that never configured the provider — it breaks every migration, not just ones using Hugging Face. This is currently failing the Migrations E2E suite on the Appwrite PR.

Only `clientId` migrates (to the destination's `huggingfaceAppid` attribute); `clientSecret` is write-only and stays redacted per the existing policy. Hugging Face uses the default `clientId`/`clientSecret` field names and exposes no extra settings (`'form' => false` in the Appwrite config), so it needs no `TARGET_SECRET` fields — same shape as `github`.

Same change as #0eb1a58 (`Add appwrite OAuth2 provider to migration allow-list`).

## Test Plan

- Added `testFromArrayHuggingFace`, mirroring `testFromArrayAppwrite`: asserts `clientId` lands on the app ID target, no secret fields are produced, and `clientSecret` is not copied into settings.
- `testFromArrayNeverCopiesSecrets` already iterates `array_keys(OAuth2Provider::PROVIDERS)`, so it now covers the new key too.

## Follow-up

Needs a `2.0.4` tag, then a `composer.lock` bump on appwrite/appwrite#13123 (its `^2.0.0` constraint already allows it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)